### PR TITLE
Fix dependency conflicts in examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,6 @@ tokio-core = "0.1"
 # For examples
 prost = "0.2"
 prost-derive = "0.2"
+
+[patch.crates-io]
+http = { git = "http://github.com/hyperium/http", rev = "5f362a32278891672f428d570d46387fe6896a5d" }

--- a/tower-grpc-examples/Cargo.toml
+++ b/tower-grpc-examples/Cargo.toml
@@ -39,3 +39,6 @@ serde_derive = "1.0"
 
 [build-dependencies]
 tower-grpc-build = { path = "../tower-grpc-build" }
+
+[patch.crates-io]
+http = { git = "http://github.com/hyperium/http", rev = "5f362a32278891672f428d570d46387fe6896a5d" }

--- a/tower-grpc-examples/Cargo.toml
+++ b/tower-grpc-examples/Cargo.toml
@@ -29,7 +29,7 @@ prost = "0.2"
 prost-derive = "0.2"
 tokio-core = "0.1"
 tower = { git = "https://github.com/tower-rs/tower" }
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
+tower-h2 = { git = "https://github.com/tower-rs/tower-h2", branch = "connection-handshake" }
 tower-grpc = { path = "../" }
 
 # For the routeguide example


### PR DESCRIPTION
I've encountered a couple of dependency conflicts trying to build the `tower-grpc-examples` crate against the latest master. First, `tower-grpc` depends on the `connection-handshake` branch of `tower-h2`, but `tower-grpc-examples` depends on `master`; secondly, the code generated by `tower-grpc` depends on `http::PathAndQuery` having a `from_static` function, which was added in hyperium/hyper@4be1929e0c038bc575c24c38c1b1fadb7da48069 and isn't yet published to crates.io.

I've modified the `Cargo.toml`s for `tower-grpc` and `tower-grpc-examples` to resolve these issues.