### PR TITLE
Set content type of request with associated type

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -122,13 +122,6 @@ where T: HttpService,
         request.headers_mut()
             .insert(header::TE, HeaderValue::from_static("trailers"));
 
-        // Set the content type
-        // TODO: Don't hard code this here
-        let content_type = "application/grpc+proto";
-        request.headers_mut().insert(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static(content_type));
-
         // Call the inner HTTP service
         let response = self.inner.call(request);
 

--- a/src/generic/server/grpc.rs
+++ b/src/generic/server/grpc.rs
@@ -75,6 +75,8 @@ where T: Codec,
         -> Request<Streaming<T::Decoder, B>>
     where B: Body<Data = Data>,
     {
+        use http::header::{self, HeaderValue};
+
         // Map the request body
         let (head, body) = request.into_parts();
 
@@ -82,7 +84,10 @@ where T: Codec,
         let body = Streaming::new(self.codec.decoder(), body, false);
 
         // Reconstruct the HTTP request
-        let request = http::Request::from_parts(head, body);
+        let mut request = http::Request::from_parts(head, body);
+
+        // Set the content type
+        request.headers_mut().insert(header::CONTENT_TYPE, HeaderValue::from_static(T::CONTENT_TYPE));
 
         // Convert the HTTP request to a gRPC request
         Request::from_http(request)


### PR DESCRIPTION
Even though Codec traits has CONTENT_TYPE as associated constants,
current code hard codes it.

This patch changes to add content type by the associated content type
of the implementation of Codec.