### PR TITLE
Encode only generates trailers on the server side

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -193,7 +193,7 @@ where T: Stream<Item = U, Error = ::Error> + Send + 'static,
         use codec::Encoder;
         use generic::Encode;
 
-        let encode = Encode::new(Encoder::new(), self);
+        let encode = Encode::new(Encoder::new(), self, false);
         BoxBody::new(Box::new(encode))
     }
 }

--- a/src/generic/codec.rs
+++ b/src/generic/codec.rs
@@ -143,11 +143,11 @@ where T: Encoder<Item = U::Item>,
         }
     }
 
-    pub(crate) fn error(status: Status, return_trailers: bool) -> Self {
+    pub(crate) fn error(status: Status) -> Self {
         Encode {
             inner: EncodeInner::Err(status),
             buf: BytesMut::new(),
-            return_trailers,
+            return_trailers: true,
         }
     }
 }

--- a/src/generic/codec.rs
+++ b/src/generic/codec.rs
@@ -64,6 +64,9 @@ pub struct Encode<T, U> {
 
     /// Destination buffer
     buf: BytesMut,
+
+    /// Set to true when trailers should be generated.
+    return_trailers: bool,
 }
 
 #[derive(Debug)]
@@ -132,17 +135,19 @@ impl<T, U> Encode<T, U>
 where T: Encoder<Item = U::Item>,
       U: Stream,
 {
-    pub(crate) fn new(encoder: T, inner: U) -> Self {
+    pub(crate) fn new(encoder: T, inner: U, return_trailers: bool) -> Self {
         Encode {
             inner: EncodeInner::Ok { encoder, inner },
             buf: BytesMut::new(),
+            return_trailers,
         }
     }
 
-    pub(crate) fn error(status: Status) -> Self {
+    pub(crate) fn error(status: Status, return_trailers: bool) -> Self {
         Encode {
             inner: EncodeInner::Err(status),
             buf: BytesMut::new(),
+            return_trailers,
         }
     }
 }
@@ -188,6 +193,10 @@ where T: Encoder<Item = U::Item>,
     }
 
     fn poll_trailers(&mut self) -> Poll<Option<HeaderMap>, h2::Error> {
+        if !self.return_trailers {
+            return Ok(Async::Ready(None));
+        }
+
         let mut map = HeaderMap::new();
 
         let status = match self.inner {

--- a/src/generic/server/streaming.rs
+++ b/src/generic/server/streaming.rs
@@ -43,7 +43,9 @@ where T: Future<Item = Response<S>,
             Err(e) => {
                 match e {
                     ::Error::Grpc(status) => {
-                        let response = Response::new(Encode::error(status));
+                        let response = Response::new(
+                            Encode::error(status, true)
+                        );
                         return Ok(response.into_http().into());
                     }
                     // TODO: Is this correct?
@@ -62,7 +64,7 @@ where T: Future<Item = Response<S>,
         let encoder = self.encoder.take().expect("encoder consumed");
 
         // Encode the body
-        let body = Encode::new(encoder, body);
+        let body = Encode::new(encoder, body, true);
 
         // Success
         Ok(http::Response::from_parts(head, body).into())

--- a/src/generic/server/streaming.rs
+++ b/src/generic/server/streaming.rs
@@ -43,9 +43,7 @@ where T: Future<Item = Response<S>,
             Err(e) => {
                 match e {
                     ::Error::Grpc(status) => {
-                        let response = Response::new(
-                            Encode::error(status, true)
-                        );
+                        let response = Response::new(Encode::error(status));
                         return Ok(response.into_http().into());
                     }
                     // TODO: Is this correct?


### PR DESCRIPTION
Fixes #12.

In 16c02a216a3f45779878c95dc492ae5e52bb0665, the client and server were refactored to share one generic `Encode` implementation. However, this resulted in client request streams ending in trailers when they weren't supposed to, breaking compatibility with other gRPC implementations (see https://github.com/tower-rs/tower-grpc/issues/12#issuecomment-354369747).

I added a boolean `return_trailers` field on `Encode`, which is now set `true` by servers and `false` by clients. 

Tested against `grpc-go` and `grpc-java`'s `helloworld` examples, and the issue described in #12 no longer occurs.