### PR TITLE
Add functions for accessing Request header map

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -25,6 +25,16 @@ impl<T> Request<T> {
         &mut self.message
     }
 
+    /// Get a reference to the request headers.
+    pub fn headers(&self) -> &http::HeaderMap {
+        &self.headers
+    }
+
+    /// Get a mutable reference to the request headers.
+    pub fn headers_mut(&mut self) -> &mut http::HeaderMap {
+        &mut self.headers
+    }
+
     /// Consumes `self`, returning the message
     pub fn into_inner(self) -> T {
         self.message


### PR DESCRIPTION
I've added accessor functions to `Request` for getting the header map. I need to add headers to a request for [one of the gRPC interop test cases](https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md#cacheable_unary), and this seemed like the most ergonomic way to do it.