### PR TITLE
Fix build errors with tower-h2 connection-handshake branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ http = "0.1"
 h2 = { git = "https://github.com/carllerche/h2" }
 log = "0.3"
 tower = { git = "https://github.com/tower-rs/tower" }
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2", branch = "connection-handshake" }
+tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 
 # For protobuf
 prost = { version = "0.2", optional = true }

--- a/tower-grpc-examples/Cargo.toml
+++ b/tower-grpc-examples/Cargo.toml
@@ -29,7 +29,7 @@ prost = "0.2"
 prost-derive = "0.2"
 tokio-core = "0.1"
 tower = { git = "https://github.com/tower-rs/tower" }
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2", branch = "connection-handshake" }
+tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-grpc = { path = "../" }
 
 # For the routeguide example


### PR DESCRIPTION
A fresh clone generates the following errors:

```
$ cargo build
    Updating git repository `http://github.com/hyperium/http`
    Updating git repository `https://github.com/carllerche/codegen`             
    Updating registry `https://github.com/rust-lang/crates.io-index`            
    Updating git repository `https://github.com/tower-rs/tower`
    Updating git repository `https://github.com/tower-rs/tower-h2`              
    Updating git repository `https://github.com/carllerche/h2`                  
    Updating git repository `https://github.com/carllerche/tokio-connect`       
    Updating git repository `https://github.com/carllerche/string`              
   Compiling libc v0.2.35                                                       
   Compiling fnv v1.0.6
   Compiling scoped-tls v0.1.0
   Compiling cfg-if v0.1.2
   Compiling ordermap v0.2.13
   Compiling slab v0.4.0
   Compiling byteorder v1.2.1
   Compiling lazycell v0.5.1
   Compiling string v0.1.0 (https://github.com/carllerche/string#376413b9)
   Compiling futures v0.1.17
   Compiling slab v0.3.0
   Compiling log v0.4.1
   Compiling net2 v0.2.31
   Compiling iovec v0.1.1
   Compiling bytes v0.4.5
   Compiling log v0.3.9
   Compiling mio v0.6.11
   Compiling http v0.1.3 (http://github.com/hyperium/http?rev=5f362a32278891672f428d570d46387fe6896a5d#5f362a32)
   Compiling prost v0.2.3
   Compiling tokio-io v0.1.4
   Compiling tower v0.1.0 (https://github.com/tower-rs/tower#1125d1cb)
   Compiling tokio-connect v0.1.0 (https://github.com/carllerche/tokio-connect#f413067d)
   Compiling tokio-core v0.1.11
   Compiling h2 v0.1.0 (https://github.com/carllerche/h2#6f7b826b)
   Compiling tower-h2 v0.1.0 (https://github.com/tower-rs/tower-h2?branch=connection-handshake#721029a3)
error[E0432]: unresolved import `h2::client::Client`
 --> /home/myagley/.cargo/git/checkouts/tower-h2-aaf68b3c8982de4c/721029a/src/client/connection.rs:9:24
  |
9 | use h2::client::{self, Client, Builder};
  |                        ^^^^^^ no `Client` in `client`

error[E0432]: unresolved import `h2::server::Server`
 --> /home/myagley/.cargo/git/checkouts/tower-h2-aaf68b3c8982de4c/721029a/src/server/mod.rs:6:18
  |
6 | use h2::server::{Server as Accept, Handshake, Respond};
  |                  ^^^^^^^^^^^^^^^^ no `Server` in `server`

error[E0432]: unresolved import `h2::server::Respond`
 --> /home/myagley/.cargo/git/checkouts/tower-h2-aaf68b3c8982de4c/721029a/src/server/mod.rs:6:47
  |
6 | use h2::server::{Server as Accept, Handshake, Respond};
  |                                               ^^^^^^^ no `Respond` in `server`

error: aborting due to 3 previous errors

error: Could not compile `tower-h2`.

To learn more, run the command again with --verbose.

```

This PR moves the `tower-h2` dependency back to `master` from the `connection-handshake` branch (which looks like it was merged a little while back.)