### PR TITLE
Zero codegen::Scope in ServiceGenerator::finalize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ members = [
   "tower-grpc-build",
   "tower-grpc-examples",
   "tower-grpc-interop",
+
+  # For tests
+  "tests/multifile",
 ]
 
 [dependencies]

--- a/tests/multifile/Cargo.toml
+++ b/tests/multifile/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "multifile"
+version = "0.1.0"
+authors = ["Carl Lerche <me@carllerche.com>"]
+publish = false
+
+[dependencies]
+bytes = "0.4"
+prost = { git = "https://github.com/danburkert/prost" }
+prost-derive = { git = "https://github.com/danburkert/prost" }
+tower-grpc = { path = "../../" }
+
+[build-dependencies]
+tower-grpc-build = { path = "../../tower-grpc-build" }

--- a/tests/multifile/build.rs
+++ b/tests/multifile/build.rs
@@ -1,0 +1,13 @@
+extern crate tower_grpc_build;
+
+fn main() {
+    // Build multifile
+    tower_grpc_build::Config::new()
+        .enable_server(true)
+        .enable_client(true)
+        .build(&["proto/hello.proto",
+                 "proto/world.proto"],
+               &["proto"])
+        .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
+}
+

--- a/tests/multifile/proto/hello.proto
+++ b/tests/multifile/proto/hello.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package hello;
+
+// A basic message
+message HelloRequest {
+  string name = 1;
+}
+
+// The response
+message HelloReply {
+  string message = 1;
+}
+
+// The greeting service definition.
+service Hello {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}

--- a/tests/multifile/proto/world.proto
+++ b/tests/multifile/proto/world.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package world;
+
+// A basic message
+message WorldRequest {
+  string name = 1;
+}
+
+// The response
+message WorldReply {
+  string message = 1;
+}
+
+// The greeting service definition.
+service World {
+  // Sends a greeting
+  rpc SayWorld (WorldRequest) returns (WorldReply) {}
+}

--- a/tests/multifile/src/lib.rs
+++ b/tests/multifile/src/lib.rs
@@ -1,0 +1,24 @@
+extern crate bytes;
+extern crate prost;
+#[macro_use]
+extern crate prost_derive;
+extern crate tower_grpc;
+
+pub mod hello {
+    include!(concat!(env!("OUT_DIR"), "/hello.rs"));
+}
+
+pub mod world {
+    include!(concat!(env!("OUT_DIR"), "/world.rs"));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem;
+
+    #[test]
+    fn types_are_present() {
+        mem::size_of::<::hello::HelloRequest>();
+        mem::size_of::<::world::WorldRequest>();
+    }
+}

--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -14,7 +14,7 @@ impl ServiceGenerator {
         self.define(service, scope);
     }
 
-    fn define(&self, 
+    fn define(&self,
               service: &prost_build::Service,
               scope: &mut codegen::Scope) {
         // Create scope that contains the generated client code.
@@ -30,9 +30,9 @@ impl ServiceGenerator {
         self.define_client_impl(service, scope);
     }
 
-    fn import_message_types(&self, 
-                            service: &prost_build::Service, 
-                            scope: &mut codegen::Scope) 
+    fn import_message_types(&self,
+                            service: &prost_build::Service,
+                            scope: &mut codegen::Scope)
     {
         for method in &service.methods {
             let (input_path, input_type) = ::super_import(&method.input_type, 1);
@@ -43,9 +43,9 @@ impl ServiceGenerator {
         }
     }
 
-    fn define_client_struct(&self, 
-                            service: &prost_build::Service, 
-                            scope: &mut codegen::Scope) 
+    fn define_client_struct(&self,
+                            service: &prost_build::Service,
+                            scope: &mut codegen::Scope)
     {
         scope.new_struct(&service.name)
             .vis("pub")
@@ -55,9 +55,9 @@ impl ServiceGenerator {
             ;
     }
 
-    fn define_client_impl(&self, 
+    fn define_client_impl(&self,
                           service: &prost_build::Service,
-                          scope: &mut codegen::Scope) 
+                          scope: &mut codegen::Scope)
     {
         let imp = scope.new_impl(&service.name)
             .generic("T")

--- a/tower-grpc-build/src/lib.rs
+++ b/tower-grpc-build/src/lib.rs
@@ -86,8 +86,8 @@ impl Config {
 impl prost_build::ServiceGenerator for ServiceGenerator {
 
     fn generate(&self, service: prost_build::Service, _buf: &mut String) {
-        // Note that neither this implementation of `generate` nor the 
-        // implementations for `client::ServiceGenerator` and 
+        // Note that neither this implementation of `generate` nor the
+        // implementations for `client::ServiceGenerator` and
         // `server::ServiceGenerator` will actually output any code to the
         // buffer; all code is written out in the implementation of the
         // `ServiceGenerator::finalize` function on this type.
@@ -117,7 +117,13 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
         let mut fmt = codegen::Formatter::new(buf);
         self.root_scope.borrow()
             .fmt(&mut fmt)
-            .expect("formatting root scope failed!")
+            .expect("formatting root scope failed!");
+
+        // reset the root scope so that the service generator is ready to
+        // generate another file. this prevents the code generated for *this*
+        // file being present in the next file.
+        *self.root_scope.borrow_mut() = codegen::Scope::new();
+
     }
 }
 


### PR DESCRIPTION
When `tower-grpc` is invoked on multiple `.proto` files, code generated for one file can make it into multiple output files. This is because the `ServiceGenerator` reuses the file root `codegen::Scope` even after it is `finalize()`ed.

I've changed `ServiceGenerator::finalize()` to replace the scope with a fresh one after outputting the generated code.

Fixes #31 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>