### PR TITLE
Depend on h2 from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 bytes = "0.4"
 futures = "0.1"
 http = "0.1"
-h2 = { git = "https://github.com/carllerche/h2" }
+h2 = "0.1"
 log = "0.3"
 tower = { git = "https://github.com/tower-rs/tower" }
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }


### PR DESCRIPTION
This should fix compile errors against tower-rs/tower-h2@3c053d2d637e35f652e2533d27550d1d7065b107, caused by dependencies on different versions of `h2`.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>