### PR TITLE
Handle proto import collisions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
 
   # For tests
   "tests/multifile",
+  "tests/collide",
 ]
 
 [dependencies]

--- a/tests/collide/Cargo.toml
+++ b/tests/collide/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "collide"
+version = "0.1.0"
+authors = ["Carl Lerche <me@carllerche.com>"]
+publish = false
+
+[dependencies]
+bytes = "0.4"
+prost = { git = "https://github.com/danburkert/prost" }
+prost-derive = { git = "https://github.com/danburkert/prost" }
+tower-grpc = { path = "../../" }
+
+[build-dependencies]
+tower-grpc-build = { path = "../../tower-grpc-build" }

--- a/tests/collide/build.rs
+++ b/tests/collide/build.rs
@@ -5,8 +5,6 @@ fn main() {
     tower_grpc_build::Config::new()
         .enable_server(true)
         .enable_client(true)
-        .build(&["proto/hello.proto",
-                 "proto/world.proto"],
-               &["proto"])
+        .build(&["proto/hello.proto"], &["proto"])
         .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
 }

--- a/tests/collide/proto/common.proto
+++ b/tests/collide/proto/common.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package common;
+
+// A basic message
+message HelloRequest {
+  string name = 1;
+}
+
+// The response
+message HelloReply {
+  string message = 1;
+}

--- a/tests/collide/proto/hello.proto
+++ b/tests/collide/proto/hello.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package hello;
+
+import "common.proto";
+
+// A different HelloRequest
+message HelloRequest {
+  string name = 2;
+}
+
+// The greeting service definition.
+service Hello {
+  // Sends a greeting
+  rpc SayHello (common.HelloRequest) returns (common.HelloReply) {}
+
+  rpc SayHello2 (HelloRequest) returns (common.HelloReply) {}
+}

--- a/tests/collide/src/lib.rs
+++ b/tests/collide/src/lib.rs
@@ -1,0 +1,24 @@
+extern crate bytes;
+extern crate prost;
+#[macro_use]
+extern crate prost_derive;
+extern crate tower_grpc;
+
+pub mod common {
+    include!(concat!(env!("OUT_DIR"), "/common.rs"));
+}
+
+pub mod hello {
+    include!(concat!(env!("OUT_DIR"), "/hello.rs"));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem;
+
+    #[test]
+    fn types_are_present() {
+        mem::size_of::<::hello::HelloRequest>();
+    }
+}
+

--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -38,8 +38,8 @@ impl ServiceGenerator {
             let (input_path, input_type) = ::super_import(&method.input_type, 1);
             let (output_path, output_type) = ::super_import(&method.output_type, 1);
 
-            scope.import(&input_path, input_type);
-            scope.import(&output_path, output_type);
+            scope.import(&input_path, &input_type);
+            scope.import(&output_path, &output_type);
         }
     }
 
@@ -104,7 +104,7 @@ impl ServiceGenerator {
                         "grpc::unary::ResponseFuture<{}, T::Future, T::ResponseBody>",
                         output_type);
 
-                    request.generic(input_type);
+                    request.generic(&input_type);
 
                     func.ret(ret)
                         .line("self.inner.unary(request, path)")
@@ -117,7 +117,7 @@ impl ServiceGenerator {
                         "grpc::server_streaming::ResponseFuture<{}, T::Future>",
                         output_type);
 
-                    request.generic(input_type);
+                    request.generic(&input_type);
 
                     func.generic("B")
                         .ret(ret)

--- a/tower-grpc-build/src/lib.rs
+++ b/tower-grpc-build/src/lib.rs
@@ -154,18 +154,46 @@ fn lower_name(name: &str) -> String {
     ret
 }
 
-fn super_import(ty: &str, level: usize) -> (String, &str) {
+fn super_import(ty: &str, mut level: usize) -> (String, String) {
     let mut v: Vec<&str> = ty.split("::").collect();
+
+    let full_import = v.len() == 1;
+
+    if !full_import {
+        if level > 1 {
+            // proto modules get imported at the root of `client` and `server`,
+            // so if `level` is greater than 1, we want to reference the import
+            // instead of the actual module.
+            level -= 1;
+        }
+    }
 
     for _ in 0..level {
         v.insert(0, "super");
     }
 
-    let last = v.pop().unwrap_or(ty);
+    let ty = v.pop().unwrap_or(ty);
 
-    (v.join("::"), last)
+    if full_import {
+        (v.join("::"), ty.to_string())
+    } else {
+        let module = v.pop().unwrap();
+
+        (v.join("::"), [module, ty].join("::"))
+    }
 }
 
-fn unqualified(ty: &str) -> &str {
-    ty.rsplit("::").next().unwrap_or(ty)
+fn unqualified(ty: &str) -> String {
+    let mut v: Vec<&str> = ty.split("::").collect();
+
+    let full_import = v.len() == 1;
+
+    if full_import {
+        ty.to_string()
+    } else {
+        let ty = v.pop().unwrap();
+        let module = v.pop().unwrap();
+
+        [module, ty].join("::")
+    }
 }

--- a/tower-grpc-build/src/server.rs
+++ b/tower-grpc-build/src/server.rs
@@ -62,8 +62,8 @@ macro_rules! try_ready {
                 let (input_path, input_type) = ::super_import(&method.input_type, 2);
                 let (output_path, output_type) = ::super_import(&method.output_type, 2);
 
-                methods.import(&input_path, input_type);
-                methods.import(&output_path, output_type);
+                methods.import(&input_path, &input_type);
+                methods.import(&output_path, &output_type);
 
                 self.define_service_method(service, method, methods);
             }
@@ -111,8 +111,8 @@ macro_rules! try_ready {
             let (input_path, input_type) = ::super_import(&method.input_type, 1);
             let (output_path, output_type) = ::super_import(&method.output_type, 1);
 
-            scope.import(&input_path, input_type);
-            scope.import(&output_path, output_type);
+            scope.import(&input_path, &input_type);
+            scope.import(&output_path, &output_type);
 
             let response_type = if method.client_streaming {
                 format!("grpc::Request<grpc::Streaming<{}>>", input_type)


### PR DESCRIPTION
Types from external proto files have their modules
imported and references are scoped by the imported
module.

Closes #33