### PR TITLE
Fix client server streaming codgen

### DIFF
--- a/tests/multifile/Cargo.toml
+++ b/tests/multifile/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 bytes = "0.4"
 prost = { git = "https://github.com/danburkert/prost" }
 prost-derive = { git = "https://github.com/danburkert/prost" }
+tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-grpc = { path = "../../" }
 
 [build-dependencies]

--- a/tests/multifile/proto/hello.proto
+++ b/tests/multifile/proto/hello.proto
@@ -16,4 +16,7 @@ message HelloReply {
 service Hello {
   // Sends a greeting
   rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+  // Receive a streaming response
+  rpc SayHello2 (HelloRequest) returns (stream HelloReply) {}
 }

--- a/tests/multifile/src/lib.rs
+++ b/tests/multifile/src/lib.rs
@@ -2,6 +2,7 @@ extern crate bytes;
 extern crate prost;
 #[macro_use]
 extern crate prost_derive;
+extern crate tower_h2;
 extern crate tower_grpc;
 
 pub mod hello {
@@ -20,5 +21,25 @@ mod tests {
     fn types_are_present() {
         mem::size_of::<::hello::HelloRequest>();
         mem::size_of::<::world::WorldRequest>();
+    }
+
+    #[test]
+    fn can_call() {
+        use ::hello::{HelloRequest};
+        use ::hello::client::Hello;
+        use ::tower_h2::BoxBody;
+        use ::tower_grpc::codegen::client::*;
+
+        #[allow(dead_code)]
+        fn zomg<T>(client: &mut Hello<T>)
+        where T: tower_h2::HttpService<RequestBody = BoxBody>,
+        {
+            let request = HelloRequest {
+                name: "hello".to_string(),
+            };
+
+            let _ = client.say_hello(grpc::Request::new(request.clone()));
+            let _ = client.say_hello2(grpc::Request::new(request.clone()));
+        }
     }
 }

--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -121,8 +121,7 @@ impl ServiceGenerator {
 
                     request.generic(&input_type);
 
-                    func.generic("B")
-                        .ret(ret)
+                    func.ret(ret)
                         .line("self.inner.server_streaming(request, path)")
                         ;
 


### PR DESCRIPTION
The existing codegen included an unused generic, which prevents calling
the actual function given that the generic can not be inferred.