### PR TITLE
Do not set the authority in the gRPC client.

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -59,8 +59,6 @@ pub mod client {
     pub mod grpc {
         pub use ::client::{
             Grpc,
-            Builder,
-            BuilderError,
             Encodable,
             unary,
             client_streaming,

--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -70,13 +70,9 @@ impl ServiceGenerator {
         imp.new_fn("new")
             .vis("pub")
             .arg("inner", "T")
-            .arg("uri", "http::Uri")
-            .ret("Result<Self, grpc::BuilderError>")
-            .line("let inner = grpc::Builder::new()")
-            .line("    .uri(uri)")
-            .line("    .build(inner)?;")
-            .line("")
-            .line("Ok(Self { inner })")
+            .ret("Self")
+            .line("let inner = grpc::Grpc::new(inner);")
+            .line("Self { inner }")
             ;
 
         imp.new_fn("poll_ready")

--- a/tower-grpc-examples/Cargo.toml
+++ b/tower-grpc-examples/Cargo.toml
@@ -30,6 +30,7 @@ prost-derive = { git = "https://github.com/danburkert/prost" }
 tokio-core = "0.1"
 tower = { git = "https://github.com/tower-rs/tower" }
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
+tower-http = { git = "https://github.com/tower-rs/tower-http" }
 tower-grpc = { path = "../" }
 
 # For the routeguide example

--- a/tower-grpc-interop/Cargo.toml
+++ b/tower-grpc-interop/Cargo.toml
@@ -18,6 +18,7 @@ prost-derive = { git = "https://github.com/danburkert/prost" }
 tokio-core = "0.1"
 tower = { git = "https://github.com/tower-rs/tower" }
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
+tower-http = { git = "https://github.com/tower-rs/tower-http" }
 tower-grpc = { path = "../" }
 
 clap = "~2.29"


### PR DESCRIPTION
Currently, the gRPC client sets the authority in the outbound HTTP
request. However, this is an HTTP/2.0 concern unrelated to gRPC. As
such, the HTTP service provided to the gRPC client should be responsible
for setting the origin.