### PR TITLE
Zero codegen::Scope in ServiceGenerator::finalize, again 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ matrix:
 
 script:
   - cargo test
+  # build test crates
+  - cargo build -p multifile
+  - cargo build -p collide
   # run interop tests
   - ./tower-grpc-interop/travis-interop.sh
 

--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -1,6 +1,5 @@
 use codegen;
 use prost_build;
-use std::fmt;
 
 /// Generates service code
 pub struct ServiceGenerator;

--- a/tower-grpc-build/src/lib.rs
+++ b/tower-grpc-build/src/lib.rs
@@ -109,6 +109,10 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
         self.root_scope
             .fmt(&mut fmt)
             .expect("formatting root scope failed!");
+        // Reset the root scope so that the service generator is ready to
+        // generate another file. this prevents the code generated for *this*
+        // file being present in the next file.
+        self.root_scope = codegen::Scope::new();
     }
 }
 

--- a/tower-grpc-build/src/server.rs
+++ b/tower-grpc-build/src/server.rs
@@ -1,8 +1,6 @@
 use codegen;
 use prost_build;
 
-use std::fmt;
-
 /// Generates service code
 pub struct ServiceGenerator;
 


### PR DESCRIPTION
It looks like the code added in PR #32 to fix the issue where `ServiceGenerator`s would output duplicate code when generating code for multiple .proto files (issue #31) was [accidentally removed](https://github.com/tower-rs/tower-grpc/commit/bbf1faca7e6e04aa611117e83d318dae44fc3835#diff-d15ac6177e75577c93c4041346f98ed0L125) in #44, creating a regression that caused issue #45.  

I've added this code back.

Furthermore, I was curious as to why the `test/multifile` test crate, which was added specifically to test for this bug, didn't catch this regression. It turns out that `test/multifile` does in fact fail to build on `master`, but we don't actually try to build it on Travis. Therefore, I also added a step to the CI build that tries to build the `test/multifile` and `test/collide` code-generation test crates, so we don't merge code that breaks these cases in the future (39e73acacd1f802c0e5968295a86e69d19e82a2a).

Fixes #45.