### PR TITLE
Track Tower changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ http = "0.1"
 h2 = "0.1"
 log = "0.3"
 tower = { git = "https://github.com/tower-rs/tower" }
+tower-ready-service = { git = "https://github.com/tower-rs/tower" }
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 
 # For protobuf
@@ -43,6 +44,3 @@ tokio-core = "0.1"
 # For examples
 prost = "0.3"
 prost-derive = "0.3"
-
-[patch.crates-io]
-http = { git = "http://github.com/hyperium/http", rev = "5f362a32278891672f428d570d46387fe6896a5d" }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -50,7 +50,8 @@ pub mod server {
 
     /// Re-exported types from the `tower` crate.
     pub mod tower {
-        pub use ::tower::{Service, ReadyService, NewService};
+        pub use ::tower::{Service, NewService};
+        pub use ::tower_ready_service::ReadyService;
     }
 }
 

--- a/src/generic/server/mod.rs
+++ b/src/generic/server/mod.rs
@@ -10,7 +10,7 @@ pub use self::grpc::Grpc;
 use {Request, Response};
 
 use futures::{Future, Stream};
-use tower::ReadyService;
+use tower_ready_service::ReadyService;
 
 /// A specialization of tower::Service.
 ///

--- a/src/generic/server/unary.rs
+++ b/src/generic/server/unary.rs
@@ -5,7 +5,7 @@ use generic::server::UnaryService;
 
 use {h2, http};
 use futures::{Future, Stream, Poll};
-use tower::ReadyService;
+use tower_ready_service::ReadyService;
 
 use std::fmt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ extern crate h2;
 #[macro_use]
 extern crate log;
 extern crate tower;
+extern crate tower_ready_service;
 extern crate tower_h2;
 
 #[cfg(feature = "protobuf")]


### PR DESCRIPTION
Primarily, `ReadyService` has been moved into a dedicated crate.

Depends on https://github.com/tower-rs/tower/pull/48.