### PR TITLE
Upgrade to env_logger 0.5 and log 0.4 so that projects that use those

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bytes = "0.4"
 futures = "0.1"
 http = "0.1"
 h2 = "0.1"
-log = "0.3"
+log = "0.4"
 tower = { git = "https://github.com/tower-rs/tower" }
 tower-ready-service = { git = "https://github.com/tower-rs/tower" }
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
@@ -37,7 +37,7 @@ tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 prost = { version = "0.3", optional = true }
 
 [dev-dependencies]
-env_logger = "0.4"
+env_logger = { version = "0.5", default-features = false }
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tokio-core = "0.1"
 

--- a/tower-grpc-examples/Cargo.toml
+++ b/tower-grpc-examples/Cargo.toml
@@ -22,8 +22,8 @@ path = "src/routeguide/client.rs"
 [dependencies]
 futures = "0.1"
 bytes = "0.4"
-env_logger = "0.4"
-log = "0.3"
+env_logger = { version = "0.5", default-features = false }
+log = "0.4"
 http = "0.1"
 prost = "0.3"
 prost-derive = "0.3"

--- a/tower-grpc-interop/Cargo.toml
+++ b/tower-grpc-interop/Cargo.toml
@@ -10,8 +10,8 @@ path = "src/client.rs"
 [dependencies]
 futures = "0.1"
 bytes = "0.4"
-env_logger = "0.4"
-log = "0.3"
+env_logger = { version = "0.5", default-features = false }
+log = "0.4"
 http = "0.1"
 prost = "0.3"
 prost-derive = "0.3"


### PR DESCRIPTION
versions don't have to build both those versions and the older ones
that h2 is currently using.

Don't enable the regex support in env_logger. Applications that want
the regex support can enable it themselves; this will happen
automatically when they add their env_logger dependency.

Disable the env_logger dependency in quickcheck.

The result of this is that there are fewer dependencies. For example,
regex and its dependencies are no longer required at all, as can be
seen by observing the changes to the Cargo.lock. That said,
env_logger 0.5 does add more dependencies itself; however it seems
applications are going to use env_logger 0.5 anyway so this is still
a net gain.

Submitted on behalf of Buoyant, Inc.

Signed-off-by: Brian Smith <brian@briansmith.org>