### PR TITLE
Distinguish protocol errors from server errors

### DIFF
--- a/src/client/streaming.rs
+++ b/src/client/streaming.rs
@@ -45,7 +45,7 @@ where T: Message + Default,
         let (head, body) = response.into_parts();
 
         if let Some(status) = super::check_grpc_status(&head.headers) {
-            return Err(::Error::Grpc(status));
+            return Err(::Error::Rpc(status, head));
         }
 
         let body = Streaming::new(Decoder::new(), body, true);

--- a/src/client/streaming.rs
+++ b/src/client/streaming.rs
@@ -45,7 +45,7 @@ where T: Message + Default,
         let (head, body) = response.into_parts();
 
         if let Some(status) = super::check_grpc_status(&head.headers) {
-            return Err(::Error::Rpc(status, head));
+            return Err(::Error::Grpc(status, head.headers));
         }
 
         let body = Streaming::new(Decoder::new(), body, true);

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -120,7 +120,7 @@ where T: Message + Default,
 
     fn decode(&mut self, buf: &mut DecodeBuf) -> Result<T, ::Error> {
         Message::decode(buf)
-            .map_err(|_| unimplemented!())
+            .map_err(::Error::DecodeError)
     }
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -120,7 +120,7 @@ where T: Message + Default,
 
     fn decode(&mut self, buf: &mut DecodeBuf) -> Result<T, ::Error> {
         Message::decode(buf)
-            .map_err(::Error::DecodeError)
+            .map_err(::Error::Decode)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,11 @@
 use prost::DecodeError;
+use http::response::Parts;
 use h2;
 
 #[derive(Debug)]
 pub enum Error<T = ()> {
     Grpc(::Status),
+    Rpc(::Status, Parts),
     DecodeError(DecodeError),
     Inner(T),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,10 @@
+use prost::DecodeError;
 use h2;
 
 #[derive(Debug)]
 pub enum Error<T = ()> {
     Grpc(::Status),
+    DecodeError(DecodeError),
     Inner(T),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,22 @@
 use prost::DecodeError;
-use http::response::Parts;
+use http::HeaderMap;
 use h2;
 
 #[derive(Debug)]
 pub enum Error<T = ()> {
-    Grpc(::Status),
-    Rpc(::Status, Parts),
-    DecodeError(DecodeError),
+    Grpc(::Status, HeaderMap),
+    Protocol(ProtocolError),
+    Decode(DecodeError),
     Inner(T),
+}
+
+#[derive(Debug)]
+pub enum ProtocolError {
+    MissingTrailers,
+    MissingMessage,
+    UnexpectedEof,
+    Internal,
+    Unsupported(&'static str),
 }
 
 impl<T> From<T> for Error<T> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,7 @@ pub enum ProtocolError {
     MissingMessage,
     UnexpectedEof,
     Internal,
-    Unsupported(&'static str),
+    UnsupportedCompressionFlag(u8),
 }
 
 impl<T> From<T> for Error<T> {

--- a/src/generic/codec.rs
+++ b/src/generic/codec.rs
@@ -8,6 +8,8 @@ use tower_h2::{self, Body, Data};
 
 use std::collections::VecDeque;
 
+use error::ProtocolError;
+
 /// Encodes and decodes gRPC message types
 pub trait Codec {
     /// The content-type header for messages using this encoding.
@@ -229,7 +231,7 @@ where T: Decoder,
         }
     }
 
-    fn decode(&mut self) -> Result<Option<T::Item>, Status> {
+    fn decode(&mut self) -> Result<Option<T::Item>, ::Error> {
         if let State::ReadHeader = self.state {
             if self.bufs.remaining() < 5 {
                 return Ok(None);
@@ -239,11 +241,11 @@ where T: Decoder,
                 0 => false,
                 1 => {
                     trace!("message compressed, compression not supported yet");
-                    return Err(Status::UNIMPLEMENTED);
+                    return Err(::Error::Protocol(ProtocolError::Unsupported("compression not supported yet")));
                 },
                 _ => {
                     trace!("unexpected compression flag");
-                    return Err(Status::UNKNOWN);
+                    return Err(::Error::Protocol(ProtocolError::Unsupported("unexpected compression flag")));
                 }
             };
             let len = self.bufs.get_u32::<BigEndian>() as usize;
@@ -268,8 +270,7 @@ where T: Decoder,
                     return Ok(Some(msg));
                 },
                 Err(e) => {
-                    debug!("decoder error; err={:?}", e);
-                    return Err(Status::UNKNOWN);
+                    return Err(e);
                 }
             }
         }
@@ -291,10 +292,9 @@ where T: Decoder,
                 break;
             }
 
-            match self.decode() {
-                Ok(Some(val)) => return Ok(Async::Ready(Some(val))),
-                Ok(None) => (),
-                Err(status) => return Err(::Error::Grpc(status)),
+            match self.decode()? {
+                Some(val) => return Ok(Async::Ready(Some(val))),
+                None => (),
             }
 
             let chunk = try_ready!(self.inner.poll_data());
@@ -304,7 +304,7 @@ where T: Decoder,
             } else {
                 if self.bufs.has_remaining() {
                     trace!("unexpected EOF decoding stream");
-                    return Err(::Error::Grpc(Status::UNKNOWN))
+                    return Err(::Error::Protocol(ProtocolError::UnexpectedEof))
                 } else {
                     self.state = State::Done;
                     break;
@@ -314,11 +314,11 @@ where T: Decoder,
 
         if self.expect_trailers {
             if let Some(trailers) = try_ready!(self.inner.poll_trailers()) {
-                grpc_status(&trailers).map_err(::Error::Grpc)?;
+                grpc_status(trailers)?;
                 Ok(Async::Ready(None))
             } else {
                 trace!("receive body ended without trailers");
-                Err(::Error::Grpc(Status::UNKNOWN))
+                Err(::Error::Protocol(ProtocolError::MissingTrailers))
             }
         } else {
             Ok(Async::Ready(None))
@@ -430,16 +430,16 @@ fn h2_err() -> h2::Error {
     unimplemented!("EncodingBody map_err")
 }
 
-fn grpc_status(trailers: &HeaderMap) -> Result<(), Status> {
-    if let Some(status) = trailers.get("grpc-status") {
+fn grpc_status(mut trailers: HeaderMap) -> Result<(), ::Error> {
+    if let Some(status) = trailers.remove("grpc-status") {
         let status = Status::from_bytes(status.as_ref());
         if status.code() == ::Code::OK {
             Ok(())
         } else {
-            Err(status)
+            Err(::Error::Grpc(status, trailers))
         }
     } else {
         trace!("trailers missing grpc-status");
-        Err(Status::UNKNOWN)
+        Err(::Error::Protocol(ProtocolError::MissingTrailers))
     }
 }

--- a/src/generic/codec.rs
+++ b/src/generic/codec.rs
@@ -241,11 +241,11 @@ where T: Decoder,
                 0 => false,
                 1 => {
                     trace!("message compressed, compression not supported yet");
-                    return Err(::Error::Protocol(ProtocolError::Unsupported("compression not supported yet")));
+                    return Err(::Error::Protocol(ProtocolError::UnsupportedCompressionFlag(1)));
                 },
-                _ => {
+                f => {
                     trace!("unexpected compression flag");
-                    return Err(::Error::Protocol(ProtocolError::Unsupported("unexpected compression flag")));
+                    return Err(::Error::Protocol(ProtocolError::UnsupportedCompressionFlag(f)));
                 }
             };
             let len = self.bufs.get_u32::<BigEndian>() as usize;

--- a/src/generic/server/streaming.rs
+++ b/src/generic/server/streaming.rs
@@ -42,7 +42,7 @@ where T: Future<Item = Response<S>,
             Ok(Async::NotReady) => return Ok(Async::NotReady),
             Err(e) => {
                 match e {
-                    ::Error::Grpc(status) => {
+                    ::Error::Grpc(status, _) => {
                         let response = Response::new(Encode::error(status));
                         return Ok(response.into_http().into());
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ mod request;
 mod response;
 mod status;
 
-pub use error::Error;
+pub use error::{Error, ProtocolError};
 pub use status::{Code, Status};
 pub use request::Request;
 pub use response::Response;


### PR DESCRIPTION
It's often helpful for debugging and error handling to be able to distinguish between `Status::Unknown` from a server response and `Status::Unknown` due to something in the middle. Also, other header/trailer values are often useful for application logic.