### PR TITLE
Fix unused imports in generated code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "tests/multifile",
   "tests/collide",
   "tests/name-case",
+  "tests/unused-imports",
 ]
 
 [dependencies]

--- a/tests/unused-imports/Cargo.toml
+++ b/tests/unused-imports/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "unused-imports"
+version = "0.1.0"
+authors = ["Eliza Weisman <eliza@buoyant.io>"]
+publish = false
+
+[dependencies]
+bytes = "0.4"
+prost = "0.3"
+prost-derive = "0.3"
+tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
+tower-grpc = { path = "../../" }
+
+[build-dependencies]
+tower-grpc-build = { path = "../../tower-grpc-build" }

--- a/tests/unused-imports/build.rs
+++ b/tests/unused-imports/build.rs
@@ -1,0 +1,11 @@
+extern crate tower_grpc_build;
+
+fn main() {
+    // Build unused-imports
+    tower_grpc_build::Config::new()
+        .enable_server(true)
+        .enable_client(true)
+        .build(&["proto/hello.proto"],
+               &["proto"])
+        .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
+}

--- a/tests/unused-imports/build.rs
+++ b/tests/unused-imports/build.rs
@@ -5,7 +5,9 @@ fn main() {
     tower_grpc_build::Config::new()
         .enable_server(true)
         .enable_client(true)
-        .build(&["proto/hello.proto"],
+        .build(&["proto/client_streaming.proto",
+               &"proto/server_streaming.proto",
+               &"proto/bidi.proto"],
                &["proto"])
         .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
 }

--- a/tests/unused-imports/proto/bidi.proto
+++ b/tests/unused-imports/proto/bidi.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package bidi;
+
+// A basic message
+message HelloRequest {
+  string name = 1;
+}
+
+// The response
+message HelloReply {
+  string message = 1;
+}
+
+// The greeting service definition.
+service Hello {
+  rpc SayHello (stream HelloRequest) returns (stream HelloReply) {}
+}

--- a/tests/unused-imports/proto/client_streaming.proto
+++ b/tests/unused-imports/proto/client_streaming.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package hello;
+package client_streaming;
 
 // A basic message
 message HelloRequest {
@@ -14,7 +14,5 @@ message HelloReply {
 
 // The greeting service definition.
 service Hello {
-
-  // Receive a streaming response
-  rpc SayHello2 (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (stream HelloRequest) returns (HelloReply) {}
 }

--- a/tests/unused-imports/proto/hello.proto
+++ b/tests/unused-imports/proto/hello.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package hello;
+
+// A basic message
+message HelloRequest {
+  string name = 1;
+}
+
+// The response
+message HelloReply {
+  string message = 1;
+}
+
+// The greeting service definition.
+service Hello {
+
+  // Receive a streaming response
+  rpc SayHello2 (HelloRequest) returns (stream HelloReply) {}
+}

--- a/tests/unused-imports/proto/server_streaming.proto
+++ b/tests/unused-imports/proto/server_streaming.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package server_streaming;
+
+// A basic message
+message HelloRequest {
+  string name = 1;
+}
+
+// The response
+message HelloReply {
+  string message = 1;
+}
+
+// The greeting service definition.
+service Hello {
+  rpc SayHello (HelloRequest) returns (stream HelloReply) {}
+}

--- a/tests/unused-imports/src/lib.rs
+++ b/tests/unused-imports/src/lib.rs
@@ -1,0 +1,42 @@
+//! Reproduction for https://github.com/tower-rs/tower-grpc/issues/56
+#![deny(warnings)]
+
+extern crate bytes;
+extern crate prost;
+#[macro_use]
+extern crate prost_derive;
+extern crate tower_h2;
+extern crate tower_grpc;
+
+pub mod hello {
+    include!(concat!(env!("OUT_DIR"), "/hello.rs"));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem;
+
+    #[test]
+    fn types_are_present() {
+        mem::size_of::<::hello::HelloRequest>();
+    }
+
+    #[test]
+    fn can_call() {
+        use ::hello::{HelloRequest};
+        use ::hello::client::Hello;
+        use ::tower_h2::BoxBody;
+        use ::tower_grpc::codegen::client::*;
+
+        #[allow(dead_code)]
+        fn zomg<T>(client: &mut Hello<T>)
+        where T: tower_h2::HttpService<RequestBody = BoxBody>,
+        {
+            let request = HelloRequest {
+                name: "hello".to_string(),
+            };
+
+            let _ = client.say_hello(grpc::Request::new(request.clone()));
+        }
+    }
+}

--- a/tests/unused-imports/src/lib.rs
+++ b/tests/unused-imports/src/lib.rs
@@ -8,8 +8,14 @@ extern crate prost_derive;
 extern crate tower_h2;
 extern crate tower_grpc;
 
-pub mod hello {
-    include!(concat!(env!("OUT_DIR"), "/hello.rs"));
+pub mod server_streaming {
+    include!(concat!(env!("OUT_DIR"), "/server_streaming.rs"));
+}
+pub mod client_streaming {
+    include!(concat!(env!("OUT_DIR"), "/client_streaming.rs"));
+}
+pub mod bidi {
+    include!(concat!(env!("OUT_DIR"), "/bidi.rs"));
 }
 
 #[cfg(test)]
@@ -18,25 +24,8 @@ mod tests {
 
     #[test]
     fn types_are_present() {
-        mem::size_of::<::hello::HelloRequest>();
-    }
-
-    #[test]
-    fn can_call() {
-        use ::hello::{HelloRequest};
-        use ::hello::client::Hello;
-        use ::tower_h2::BoxBody;
-        use ::tower_grpc::codegen::client::*;
-
-        #[allow(dead_code)]
-        fn zomg<T>(client: &mut Hello<T>)
-        where T: tower_h2::HttpService<RequestBody = BoxBody>,
-        {
-            let request = HelloRequest {
-                name: "hello".to_string(),
-            };
-
-            let _ = client.say_hello(grpc::Request::new(request.clone()));
-        }
+        mem::size_of::<::server_streaming::HelloRequest>();
+        mem::size_of::<::client_streaming::HelloRequest>();
+        mem::size_of::<::bidi::HelloRequest>();
     }
 }

--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -1,5 +1,6 @@
 use codegen;
 use prost_build;
+use super::ImportType;
 
 /// Generates service code
 pub struct ServiceGenerator;
@@ -34,13 +35,11 @@ impl ServiceGenerator {
                             scope: &mut codegen::Scope)
     {
         for method in &service.methods {
-            for &ty in [&method.input_type, &method.output_type].iter() {
-                if !::is_imported_type(ty) {
-                    let (path, ty) = ::super_import(ty, 1);
-
-                    scope.import(&path, &ty);
-                }
+            if !method.client_streaming {
+                scope.import_type(&method.input_type, 1);
             }
+
+            scope.import_type(&method.output_type, 1);
         }
     }
 

--- a/tower-grpc-build/src/lib.rs
+++ b/tower-grpc-build/src/lib.rs
@@ -119,6 +119,29 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
     }
 }
 
+/// Extension trait for importing generated types into `codegen::Scope`s.
+trait ImportType {
+    fn import_type(&mut self, ty: &str, level: usize);
+}
+
+// ===== impl ImportType =====
+
+impl ImportType for codegen::Scope {
+    fn import_type(&mut self, ty: &str, level: usize) {
+        if !is_imported_type(ty) {
+            let (path, ty) = super_import(ty, level);
+
+            self.import(&path, &ty);
+        }
+    }
+}
+
+impl ImportType for codegen::Module {
+    fn import_type(&mut self, ty: &str, level: usize) {
+        self.scope().import_type(ty, level);
+    }
+}
+
 // ===== utility fns =====
 
 fn method_path(service: &prost_build::Service, method: &prost_build::Method) -> String {

--- a/tower-grpc-build/src/server.rs
+++ b/tower-grpc-build/src/server.rs
@@ -1,5 +1,6 @@
 use codegen;
 use prost_build;
+use super::ImportType;
 
 /// Generates service code
 pub struct ServiceGenerator;
@@ -49,26 +50,18 @@ macro_rules! try_ready {
             self.define_kind(service, support);
 
             // Define methods module
-            let mut methods = support.new_module("methods")
+            let methods = support.new_module("methods")
                 .vis("pub")
                 .import("::tower_grpc::codegen::server", "*")
                 .import("super::super", &service.name)
                 ;
 
-            let import_ty = |ty, methods: &mut codegen::Module| {
-                if !::is_imported_type(ty) {
-                    let (path, ty) = ::super_import(ty, 2);
-
-                    methods.import(&path, &ty);
-                }
-            };
-
             // Define service modules
             for method in &service.methods {
-                import_ty(&method.input_type, &mut methods);
+                methods.import_type(&method.input_type, 2);
 
                 if !method.server_streaming {
-                    import_ty(&method.output_type, &mut methods);
+                    methods.import_type(&method.output_type, 2);
                 }
 
                 self.define_service_method(service, method, methods);


### PR DESCRIPTION
Fixes #56 

Previously, `tower-grpc-build`'s code generation for streaming RPCs may generate unused import statements, which cause the compiler to output a warning. This can occur in the generated server code's `methods` module for server-streaming RPCs, and in the generated client module for client-streaming RPCs, with the client code importing the method's request type and the server code importing the method's response type when. these types are not needed.

I've modified the generation of import statements to check if the RPC is streaming and skip the import of the appropriate type if so. Previously, imports were generated in a `for` loop that looped over the method's input and output types in a slice, in order to reduce repetition. This was no longer possible, as this change required different behaviour for the input and output types. Instead, I've factored out the repeated code into a trait `ImportType` (implemented for `codegen::Scope` and `codegen::Module`) which is used for both the client and server code generation.

In addition, I've added a new test crate, called `unused-imports`, to reproduce this bug (in the server streaming, client streaming, and bidirectional streaming cases). The test crate is compiled with `#![deny(warnings)]` so that regressions will appear as test failures.