### PR TITLE
Track Tower changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,8 @@ futures = "0.1"
 http = "0.1"
 h2 = "0.1"
 log = "0.4"
-tower = { git = "https://github.com/tower-rs/tower" }
-tower-ready-service = { git = "https://github.com/tower-rs/tower" }
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
+tower-service = { git = "https://github.com/tower-rs/tower" }
 
 # For protobuf
 prost = { version = "0.3", optional = true }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -50,8 +50,7 @@ pub mod server {
 
     /// Re-exported types from the `tower` crate.
     pub mod tower {
-        pub use ::tower::{Service, NewService};
-        pub use ::tower_ready_service::ReadyService;
+        pub use ::tower_service::{Service, NewService};
     }
 }
 

--- a/src/generic/server/mod.rs
+++ b/src/generic/server/mod.rs
@@ -10,11 +10,11 @@ pub use self::grpc::Grpc;
 use {Request, Response};
 
 use futures::{Future, Stream};
-use tower_ready_service::ReadyService;
+use tower_service::Service;
 
-/// A specialization of tower::Service.
+/// A specialization of tower_service::Service.
 ///
-/// Existing tower::Service implementations with the correct form will
+/// Existing tower_service::Service implementations with the correct form will
 /// automatically implement `GrpcService`.
 pub trait StreamingService {
     /// Protobuf request message type
@@ -37,9 +37,9 @@ pub trait StreamingService {
 }
 
 impl<T, S1, S2> StreamingService for T
-where T: ReadyService<Request = Request<S1>,
-                     Response = Response<S2>,
-                        Error = ::Error>,
+where T: Service<Request = Request<S1>,
+                Response = Response<S2>,
+                   Error = ::Error>,
       S1: Stream<Error = ::Error>,
       S2: Stream<Error = ::Error>,
 {
@@ -50,13 +50,13 @@ where T: ReadyService<Request = Request<S1>,
     type Future = T::Future;
 
     fn call(&mut self, request: T::Request) -> Self::Future {
-        ReadyService::call(self, request)
+        Service::call(self, request)
     }
 }
 
-/// A specialization of tower::Service.
+/// A specialization of tower_service::Service.
 ///
-/// Existing tower::Service implementations with the correct form will
+/// Existing tower_service::Service implementations with the correct form will
 /// automatically implement `UnaryService`.
 pub trait UnaryService {
     /// Protobuf request message type
@@ -73,22 +73,22 @@ pub trait UnaryService {
 }
 
 impl<T, M1, M2> UnaryService for T
-where T: ReadyService<Request = Request<M1>,
-                     Response = Response<M2>,
-                        Error = ::Error>,
+where T: Service<Request = Request<M1>,
+                Response = Response<M2>,
+                   Error = ::Error>,
 {
     type Request = M1;
     type Response = M2;
     type Future = T::Future;
 
     fn call(&mut self, request: T::Request) -> Self::Future {
-        ReadyService::call(self, request)
+        Service::call(self, request)
     }
 }
 
-/// A specialization of tower::Service.
+/// A specialization of tower_service::Service.
 ///
-/// Existing tower::Service implementations with the correct form will
+/// Existing tower_service::Service implementations with the correct form will
 /// automatically implement `UnaryService`.
 pub trait ClientStreamingService {
     /// Protobuf request message type
@@ -108,9 +108,9 @@ pub trait ClientStreamingService {
 }
 
 impl<T, M, S> ClientStreamingService for T
-where T: ReadyService<Request = Request<S>,
-                     Response = Response<M>,
-                        Error = ::Error>,
+where T: Service<Request = Request<S>,
+                Response = Response<M>,
+                   Error = ::Error>,
       S: Stream<Error = ::Error>,
 {
     type Request = S::Item;
@@ -119,13 +119,13 @@ where T: ReadyService<Request = Request<S>,
     type Future = T::Future;
 
     fn call(&mut self, request: T::Request) -> Self::Future {
-        ReadyService::call(self, request)
+        Service::call(self, request)
     }
 }
 
-/// A specialization of tower::Service.
+/// A specialization of tower_service::Service.
 ///
-/// Existing tower::Service implementations with the correct form will
+/// Existing tower_service::Service implementations with the correct form will
 /// automatically implement `UnaryService`.
 pub trait ServerStreamingService {
     /// Protobuf request message type
@@ -145,9 +145,9 @@ pub trait ServerStreamingService {
 }
 
 impl<T, M, S> ServerStreamingService for T
-where T: ReadyService<Request = Request<M>,
-                     Response = Response<S>,
-                        Error = ::Error>,
+where T: Service<Request = Request<M>,
+                Response = Response<S>,
+                   Error = ::Error>,
       S: Stream<Error = ::Error>,
 {
     type Request = M;
@@ -156,6 +156,6 @@ where T: ReadyService<Request = Request<M>,
     type Future = T::Future;
 
     fn call(&mut self, request: T::Request) -> Self::Future {
-        ReadyService::call(self, request)
+        Service::call(self, request)
     }
 }

--- a/src/generic/server/unary.rs
+++ b/src/generic/server/unary.rs
@@ -5,7 +5,7 @@ use generic::server::UnaryService;
 
 use {h2, http};
 use futures::{Future, Stream, Poll};
-use tower_ready_service::ReadyService;
+use tower_service::Service;
 
 use std::fmt;
 
@@ -56,13 +56,17 @@ where T: UnaryService<Request = S::Item, Response = E::Item>,
 
 // ===== impl Inner =====
 
-impl<T> ReadyService for Inner<T>
+impl<T> Service for Inner<T>
 where T: UnaryService,
 {
     type Request = Request<T::Request>;
     type Response = Response<Once<T::Response>>;
     type Error = ::Error;
     type Future = InnerFuture<T::Future>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        Ok(().into())
+    }
 
     fn call(&mut self, request: Self::Request) -> Self::Future {
         let inner = self.0.call(request);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,8 @@ extern crate http;
 extern crate h2;
 #[macro_use]
 extern crate log;
-extern crate tower;
-extern crate tower_ready_service;
 extern crate tower_h2;
+extern crate tower_service;
 
 #[cfg(feature = "protobuf")]
 extern crate prost;

--- a/tower-grpc-examples/Cargo.toml
+++ b/tower-grpc-examples/Cargo.toml
@@ -28,10 +28,10 @@ http = "0.1"
 prost = "0.3"
 prost-derive = "0.3"
 tokio-core = "0.1"
-tower = { git = "https://github.com/tower-rs/tower" }
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-http = { git = "https://github.com/tower-rs/tower-http" }
 tower-grpc = { path = "../" }
+tower-service = { git = "https://github.com/tower-rs/tower" }
 
 # For the routeguide example
 serde = "1.0"

--- a/tower-grpc-examples/src/helloworld/server.rs
+++ b/tower-grpc-examples/src/helloworld/server.rs
@@ -7,7 +7,6 @@ extern crate prost;
 #[macro_use]
 extern crate prost_derive;
 extern crate tokio_core;
-extern crate tower;
 extern crate tower_h2;
 extern crate tower_grpc;
 

--- a/tower-grpc-examples/src/routeguide/client.rs
+++ b/tower-grpc-examples/src/routeguide/client.rs
@@ -10,7 +10,6 @@ extern crate prost;
 #[macro_use]
 extern crate prost_derive;
 extern crate tokio_core;
-extern crate tower;
 extern crate tower_h2;
 extern crate tower_http;
 extern crate tower_grpc;

--- a/tower-grpc-examples/src/routeguide/server.rs
+++ b/tower-grpc-examples/src/routeguide/server.rs
@@ -10,7 +10,6 @@ extern crate prost;
 #[macro_use]
 extern crate prost_derive;
 extern crate tokio_core;
-extern crate tower;
 extern crate tower_h2;
 extern crate tower_grpc;
 

--- a/tower-grpc-interop/Cargo.toml
+++ b/tower-grpc-interop/Cargo.toml
@@ -16,10 +16,10 @@ http = "0.1"
 prost = "0.3"
 prost-derive = "0.3"
 tokio-core = "0.1"
-tower = { git = "https://github.com/tower-rs/tower" }
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-http = { git = "https://github.com/tower-rs/tower-http" }
 tower-grpc = { path = "../" }
+tower-service = { git = "https://github.com/tower-rs/tower" }
 
 clap = "~2.29"
 console = "0.5.0"

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -13,7 +13,6 @@ extern crate prost;
 extern crate prost_derive;
 extern crate tokio_core;
 extern crate rustls;
-extern crate tower;
 extern crate tower_http;
 extern crate tower_h2;
 extern crate tower_grpc;


### PR DESCRIPTION
This patch tracks the recent Tower changes:

* `Service` is moved to the `tower-service` crate.
* `ReadyService` is removed in favor of `Service`.

Implementations of `ReadyService` are switched to `Service` with a
`poll_ready` function that always returns `Ready`.