### PR TITLE
Update to prost-0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-service = { git = "https://github.com/tower-rs/tower" }
 
 # For protobuf
-prost = { version = "0.3", optional = true }
+prost = { version = "0.4", optional = true }
 
 [dev-dependencies]
 env_logger = { version = "0.5", default-features = false }
@@ -43,5 +43,5 @@ tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tokio-core = "0.1"
 
 # For examples
-prost = "0.3"
-prost-derive = "0.3"
+prost = "0.4"
+prost-derive = "0.4"

--- a/tests/collide/Cargo.toml
+++ b/tests/collide/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 bytes = "0.4"
-prost = "0.3"
-prost-derive = "0.3"
+prost = "0.4"
+prost-derive = "0.4"
 tower-grpc = { path = "../../" }
 
 [build-dependencies]

--- a/tests/multifile/Cargo.toml
+++ b/tests/multifile/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 bytes = "0.4"
-prost = "0.3"
-prost-derive = "0.3"
+prost = "0.4"
+prost-derive = "0.4"
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-grpc = { path = "../../" }
 

--- a/tests/name-case/Cargo.toml
+++ b/tests/name-case/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 bytes = "0.4"
-prost = "0.3"
-prost-derive = "0.3"
+prost = "0.4"
+prost-derive = "0.4"
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-grpc = { path = "../../" }
 

--- a/tests/unused-imports/Cargo.toml
+++ b/tests/unused-imports/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 bytes = "0.4"
-prost = "0.3"
-prost-derive = "0.3"
+prost = "0.4"
+prost-derive = "0.4"
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-grpc = { path = "../../" }
 

--- a/tower-grpc-build/Cargo.toml
+++ b/tower-grpc-build/Cargo.toml
@@ -6,5 +6,5 @@ license = "MIT"
 
 [dependencies]
 codegen = { git = "https://github.com/carllerche/codegen" }
-prost-build = "0.3"
+prost-build = "0.4"
 heck = "0.3"

--- a/tower-grpc-examples/Cargo.toml
+++ b/tower-grpc-examples/Cargo.toml
@@ -25,8 +25,8 @@ bytes = "0.4"
 env_logger = { version = "0.5", default-features = false }
 log = "0.4"
 http = "0.1"
-prost = "0.3"
-prost-derive = "0.3"
+prost = "0.4"
+prost-derive = "0.4"
 tokio-core = "0.1"
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-http = { git = "https://github.com/tower-rs/tower-http" }

--- a/tower-grpc-interop/Cargo.toml
+++ b/tower-grpc-interop/Cargo.toml
@@ -14,8 +14,8 @@ bytes = "0.4"
 env_logger = { version = "0.5", default-features = false }
 log = "0.4"
 http = "0.1"
-prost = "0.3"
-prost-derive = "0.3"
+prost = "0.4"
+prost-derive = "0.4"
 tokio-core = "0.1"
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-http = { git = "https://github.com/tower-rs/tower-http" }


### PR DESCRIPTION
prost-0.4.0 has been released, which removes unnecessary dependencies
and has some protobuf-specific usability improvements.

See: https://github.com/danburkert/prost/releases/tag/v0.4.0