### PR TITLE
Set Content-Type for server responses

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -48,9 +48,6 @@ impl<T, U> ::generic::Codec for Codec<T, U>
 where T: Message,
       U: Message + Default,
 {
-    /// Protocol buffer gRPC content type
-    const CONTENT_TYPE: &'static str = "application/grpc+proto";
-
     type Encode = T;
     type Encoder = Encoder<T>;
     type Decode = U;
@@ -85,6 +82,9 @@ impl<T> ::generic::Encoder for Encoder<T>
 where T: Message,
 {
     type Item = T;
+
+    /// Protocol buffer gRPC content type
+    const CONTENT_TYPE: &'static str = "application/grpc+proto";
 
     fn encode(&mut self, item: T, buf: &mut EncodeBuf) -> Result<(), ::Error> {
         let len = item.encoded_len();

--- a/src/generic/codec.rs
+++ b/src/generic/codec.rs
@@ -13,11 +13,6 @@ use error::ProtocolError;
 
 /// Encodes and decodes gRPC message types
 pub trait Codec {
-    /// The content-type header for messages using this encoding.
-    ///
-    /// Should be `application/grpc+yourencoding`.
-    const CONTENT_TYPE: &'static str;
-
     /// The encode type
     type Encode;
 
@@ -41,6 +36,11 @@ pub trait Codec {
 pub trait Encoder {
     /// Type that is encoded
     type Item;
+
+    /// The content-type header for messages using this encoding.
+    ///
+    /// Should be `application/grpc+yourencoding`.
+    const CONTENT_TYPE: &'static str;
 
     /// Encode a message into the provided buffer.
     fn encode(&mut self, item: Self::Item, buf: &mut EncodeBuf) -> Result<(), ::Error>;

--- a/src/generic/server/streaming.rs
+++ b/src/generic/server/streaming.rs
@@ -3,6 +3,7 @@ use generic::{Encoder, Encode};
 
 use {http, h2};
 use futures::{Future, Stream, Poll, Async};
+use http::header;
 
 #[derive(Debug)]
 pub struct ResponseFuture<T, E> {
@@ -56,7 +57,13 @@ where T: Future<Item = Response<S>,
         let response = response.into_http();
 
         // Map the response body
-        let (head, body) = response.into_parts();
+        let (mut head, body) = response.into_parts();
+
+        // Set the content type
+        head.headers.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static(E::CONTENT_TYPE),
+        );
 
         // Get the encoder
         let encoder = self.encoder.take().expect("encoder consumed");


### PR DESCRIPTION
The associated constant `generic::codec::Codec::CONTENT_TYPE` is currently
unused and it's not clear how it can be used to set HTTP headers.

This change moves the constant to `generic::codec::Encoder::CONTENT_TYPE` and sets the header in server responses.
