### PR TITLE
Fix client_streaming interop test

### DIFF
--- a/tower-grpc-interop/README.md
+++ b/tower-grpc-interop/README.md
@@ -8,10 +8,10 @@ Note that currently, only the interop test client is implemented. The `docker-co
 
 - [x] `empty_unary`: implemented in client
 - [ ] `cacheable_unary`: started, requires request context implementation to set cacheable flag
-- [x] `large_unary`: implemented in client, broken due to [#14](https://github.com/tower-rs/tower-grpc/issues/14)
+- [x] `large_unary`: implemented in client
 - [ ] ~`client_compressed_unary`~: requires gRPC compression, NYI
 - [ ] ~`server_compressed_unary`~: requires gRPC compression, NYI
-- [x] `client_streaming`: implemented in client, broken due to [#16](https://github.com/tower-rs/tower-grpc/issues/16)
+- [x] `client_streaming`: implemented in client
 - [ ] ~`client_compressed_streaming`~: requires gRPC compression, NYI
 - [ ] `server_streaming`
 - [ ] ~`server_compressed_streaming`~: requires gRPC compression, NYI

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -31,6 +31,7 @@ use tower_grpc::Request;
 use tower_h2::client::Connection;
 
 use pb::SimpleRequest;
+use pb::StreamingInputCallRequest;
 use pb::client::TestService;
 
 
@@ -278,12 +279,13 @@ impl Testcase {
                 unimplemented!()
             },
             Testcase::client_streaming => {
-                let stream = stream::iter_ok(vec![
-                    util::client_payload(27182),
-                    util::client_payload(8),
-                    util::client_payload(1828),
-                    util::client_payload(45904),
-                ]);
+                let requests = vec![27182, 8, 1828, 45904]
+                    .into_iter()
+                    .map(|len| StreamingInputCallRequest {
+                        payload: Some(util::client_payload(len as usize)),
+                        ..Default::default()
+                    });
+                let stream = stream::iter_ok(requests);
                 core.run(
                     client.streaming_input_call(Request::new(stream))
                         .then(|result| {

--- a/tower-grpc-interop/travis-interop.sh
+++ b/tower-grpc-interop/travis-interop.sh
@@ -24,4 +24,4 @@ trap 'echo ":; killing test server"; kill ${SERVER_PID};' EXIT
 
 # run the interop test client against the server.
 cargo run -p tower-grpc-interop --bin client -- \
-    --test_case=empty_unary,large_unary
+    --test_case=empty_unary,large_unary,client_streaming


### PR DESCRIPTION
The reason the test was failing was simply that it was streaming the wrong Protobuf message.

Fixes #16.