### PR TITLE
Add interop test cases for streaming RPCs

### DIFF
--- a/src/client/streaming.rs
+++ b/src/client/streaming.rs
@@ -47,7 +47,7 @@ where T: Message + Default,
         let trailers_only_status = super::check_grpc_status(&head.headers);
         let expect_additional_trailers = trailers_only_status.is_none();
         if let Some(status) = trailers_only_status {
-            if !status.ok() {
+            if !status.is_ok() {
                 return Err(::Error::Grpc(status, head.headers));
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,13 +25,13 @@ impl<T> fmt::Display for Error<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Grpc(ref _status, ref _header_map) =>
-                write!(f, "gRPC error"),
+                f.pad("gRPC error"),
             Error::Protocol(ref _protocol_error) =>
-                write!(f, "Protocol error"),
+                f.pad("protocol error"),
             Error::Decode(ref _decode_error) =>
-                write!(f, "Message decode error"),
+                f.pad("message decode error"),
             Error::Inner(ref _inner) =>
-                write!(f, "Inner error"),
+                f.pad("inner error"),
         }
     }
 }
@@ -40,34 +40,20 @@ impl fmt::Display for ProtocolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             ProtocolError::MissingTrailers =>
-                write!(f, "Missing trailers"),
+                f.pad("missing trailers"),
             ProtocolError::MissingMessage =>
-                write!(f, "Missing message"),
+                f.pad("missing message"),
             ProtocolError::UnexpectedEof =>
-                write!(f, "Unexpected EOF"),
+                f.pad("unexpected EOF"),
             ProtocolError::Internal =>
-                write!(f, "Internal"),
+                f.pad("internal"),
             ProtocolError::UnsupportedCompressionFlag(flag) =>
-                write!(f, "Unsupported compression flag: {}", flag),
+                write!(f, "unsupported compression flag: {}", flag),
         }
     }
 }
 
 impl std::error::Error for ProtocolError {
-    fn description(&self) -> &str {
-        match *self {
-            ProtocolError::MissingTrailers =>
-                "Missing trailers",
-            ProtocolError::MissingMessage =>
-                "Missing message",
-            ProtocolError::UnexpectedEof =>
-                "Unexpected EOF",
-            ProtocolError::Internal =>
-                "Internal",
-            ProtocolError::UnsupportedCompressionFlag(_) =>
-                "Unsupported compression flag",
-        }
-    }
 }
 
 impl<T> std::error::Error for Error<T> where T : fmt::Debug {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
 use prost::DecodeError;
 use http::HeaderMap;
 use h2;
+use std;
+use std::fmt;
 
 #[derive(Debug)]
 pub enum Error<T = ()> {
@@ -17,6 +19,66 @@ pub enum ProtocolError {
     UnexpectedEof,
     Internal,
     UnsupportedCompressionFlag(u8),
+}
+
+impl<T> fmt::Display for Error<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Grpc(ref _status, ref _header_map) =>
+                write!(f, "gRPC error"),
+            Error::Protocol(ref _protocol_error) =>
+                write!(f, "Protocol error"),
+            Error::Decode(ref _decode_error) =>
+                write!(f, "Message decode error"),
+            Error::Inner(ref _inner) =>
+                write!(f, "Inner error"),
+        }
+    }
+}
+
+impl fmt::Display for ProtocolError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ProtocolError::MissingTrailers =>
+                write!(f, "Missing trailers"),
+            ProtocolError::MissingMessage =>
+                write!(f, "Missing message"),
+            ProtocolError::UnexpectedEof =>
+                write!(f, "Unexpected EOF"),
+            ProtocolError::Internal =>
+                write!(f, "Internal"),
+            ProtocolError::UnsupportedCompressionFlag(flag) =>
+                write!(f, "Unsupported compression flag: {}", flag),
+        }
+    }
+}
+
+impl std::error::Error for ProtocolError {
+    fn description(&self) -> &str {
+        match *self {
+            ProtocolError::MissingTrailers =>
+                "Missing trailers",
+            ProtocolError::MissingMessage =>
+                "Missing message",
+            ProtocolError::UnexpectedEof =>
+                "Unexpected EOF",
+            ProtocolError::Internal =>
+                "Internal",
+            ProtocolError::UnsupportedCompressionFlag(_) =>
+                "Unsupported compression flag",
+        }
+    }
+}
+
+impl<T> std::error::Error for Error<T> where T : fmt::Debug {
+    fn cause(&self) -> Option<&std::error::Error> {
+        match *self {
+            Error::Grpc(_, _) => None,
+            Error::Protocol(ref protocol_error) => Some(protocol_error),
+            Error::Decode(ref decode_error) => Some(decode_error),
+            Error::Inner(ref _inner) => None,
+        }
+    }
 }
 
 impl<T> From<T> for Error<T> {

--- a/src/status.rs
+++ b/src/status.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use h2;
 use http::header::HeaderValue;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Status {
     code: Code,
 }
@@ -154,6 +154,10 @@ impl Status {
     fn parse_err() -> Status {
         trace!("error parsing grpc-status");
         Status::UNKNOWN
+    }
+
+    pub fn ok(&self) -> bool {
+        *self == Status::OK
     }
 }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -156,7 +156,7 @@ impl Status {
         Status::UNKNOWN
     }
 
-    pub fn ok(&self) -> bool {
+    pub fn is_ok(&self) -> bool {
         *self == Status::OK
     }
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -4,7 +4,7 @@ use h2;
 use http::header::{HeaderMap, HeaderValue};
 use http::status::StatusCode;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Status {
     code: Code,
 }
@@ -155,10 +155,6 @@ impl Status {
     fn parse_err() -> Status {
         trace!("error parsing grpc-status");
         Status::UNKNOWN
-    }
-
-    pub fn is_ok(&self) -> bool {
-        *self == Status::OK
     }
 }
 

--- a/tower-grpc-interop/Cargo.toml
+++ b/tower-grpc-interop/Cargo.toml
@@ -9,9 +9,9 @@ name = "client"
 path = "src/client.rs"
 
 [dependencies]
-futures = "0.1"
+futures = "0.1.1"
 bytes = "0.4"
-env_logger = { version = "0.5", default-features = false }
+pretty_env_logger = "0.2"
 log = "0.4"
 http = "0.1"
 prost = "0.4"

--- a/tower-grpc-interop/Cargo.toml
+++ b/tower-grpc-interop/Cargo.toml
@@ -9,7 +9,7 @@ name = "client"
 path = "src/client.rs"
 
 [dependencies]
-futures = "0.1.1"
+futures = "0.1.23"
 bytes = "0.4"
 pretty_env_logger = "0.2"
 log = "0.4"

--- a/tower-grpc-interop/README.md
+++ b/tower-grpc-interop/README.md
@@ -13,7 +13,7 @@ Note that currently, only the interop test client is implemented. The `docker-co
 - [ ] ~`server_compressed_unary`~: requires gRPC compression, NYI
 - [x] `client_streaming`: implemented in client
 - [ ] ~`client_compressed_streaming`~: requires gRPC compression, NYI
-- [ ] `server_streaming`
+- [x] `server_streaming`
 - [ ] ~`server_compressed_streaming`~: requires gRPC compression, NYI
 - [ ] `ping_pong`
 - [ ] `empty_stream`

--- a/tower-grpc-interop/README.md
+++ b/tower-grpc-interop/README.md
@@ -16,7 +16,7 @@ Note that currently, only the interop test client is implemented. The `docker-co
 - [x] `server_streaming`
 - [ ] ~`server_compressed_streaming`~: requires gRPC compression, NYI
 - [ ] `ping_pong`
-- [ ] `empty_stream`
+- [x] `empty_stream`
 - [ ] ~`compute_engine_creds`~ requires auth, NYI
 - [ ] ~`jwt_token_creds`~ requires auth, NYI
 - [ ] ~`oauth2_auth_token`~ requires auth, NYI

--- a/tower-grpc-interop/README.md
+++ b/tower-grpc-interop/README.md
@@ -15,7 +15,7 @@ Note that currently, only the interop test client is implemented. The `docker-co
 - [ ] ~`client_compressed_streaming`~: requires gRPC compression, NYI
 - [x] `server_streaming`
 - [ ] ~`server_compressed_streaming`~: requires gRPC compression, NYI
-- [ ] `ping_pong`
+- [x] `ping_pong`
 - [x] `empty_stream`
 - [ ] ~`compute_engine_creds`~ requires auth, NYI
 - [ ] ~`jwt_token_creds`~ requires auth, NYI

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -236,13 +236,13 @@ impl Testcase {
                 };
                 core.run(client.unary_call(Request::new(req))
                     .then(|result| {
-                    let mut assertions = vec![
+                        let mut assertions = vec![
                             test_assert!(
                                 "call must be successful",
                                 result.is_ok(),
                                 format!("result={:?}", result)
                             )
-                    ];
+                        ];
                         if let Ok(body) = result.map(|r| r.into_inner()) {
                             let payload_len = body.payload.as_ref()
                                 .map(|p| p.body.len())

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -217,165 +217,13 @@ fn assert_success(result: Result<Vec<TestAssertion>, Box<Error>>)
     })
 }
 
-type TestClient = pb::client::TestService<tower_http::AddOrigin<
-    tower_h2::client::Connection<
-        tokio_core::net::TcpStream, tokio_core::reactor::Handle, tower_h2::BoxBody>>>;
-
-fn empty_unary_test(client: &mut TestClient)
-        -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
-    use pb::Empty;
-    client
-        .empty_call(Request::new(Empty {}))
-        .then(|result| {
-            let mut assertions = vec![
-                test_assert!(
-                    "call must be successful",
-                    result.is_ok(),
-                    format!("result={:?}", result)
-                )
-            ];
-            if let Ok(body) = result.map(|r| r.into_inner()) {
-                assertions.push(test_assert!(
-                    "body must not be null",
-                    body == Empty{},
-                    format!("body={:?}", body)
-                ))
-            }
-            future::ok::<Vec<TestAssertion>, Box<Error>>(assertions)
-        })
-}
-
-fn large_unary_test(client: &mut TestClient)
-        -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
-    use std::mem;
-    let payload = util::client_payload(LARGE_REQ_SIZE);
-    let req = SimpleRequest {
-        response_type: pb::PayloadType::Compressable as i32,
-        response_size: LARGE_RSP_SIZE,
-        payload: Some(payload),
-        ..Default::default()
-    };
-    client
-        .unary_call(Request::new(req))
-        .then(|result| {
-            let mut assertions = vec![
-                test_assert!(
-                    "call must be successful",
-                    result.is_ok(),
-                    format!("result={:?}", result)
-                )
-            ];
-            if let Ok(body) = result.map(|r| r.into_inner()) {
-                let payload_len = body.payload.as_ref()
-                    .map(|p| p.body.len())
-                    .unwrap_or(0);
-
-                assertions.push(test_assert!(
-                "body must be 314159 bytes",
-                payload_len == LARGE_RSP_SIZE as usize,
-                format!("mem::size_of_val(&body)={:?}",
-                    mem::size_of_val(&body))
-                ));
-            }
-            future::ok::<Vec<TestAssertion>, Box<Error>>(assertions)
-        })
-}
-
-fn cacheable_unary_test(_client: &mut TestClient)
-        -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
-    let payload = pb::Payload {
-        type_: pb::PayloadType::Compressable as i32,
-        body: format!("{:?}", std::time::Instant::now()).into_bytes(),
-    };
-    let req = SimpleRequest {
-        response_type: pb::PayloadType::Compressable as i32,
-        payload: Some(payload),
-        ..Default::default()
-    };
-    let mut req = Request::new(req);
-    req.headers_mut()
-        .insert(" x-user-ip", HeaderValue::from_static("1.2.3.4"));
-    // core.run(client.unary_call(req)
-    //     .then(|result| {
-    //         unimplemented!()
-    //     })
-    // )
-    unimplemented!();
-    // This line is just a hint for the type checker
-    future::ok::<Vec<TestAssertion>, Box<Error>>(vec![])
-}
-
-fn client_streaming_test(client: &mut TestClient)
-        -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
-    let requests = REQUEST_LENGTHS
-        .iter()
-        .map(|len| StreamingInputCallRequest {
-            payload: Some(util::client_payload(*len as usize)),
-            ..Default::default()
-        });
-    let stream = stream::iter_ok(requests);
-    client
-        .streaming_input_call(Request::new(stream))
-        .then(|result| {
-            let mut assertions = vec![
-                test_assert!(
-                    "call must be successful",
-                    result.is_ok(),
-                    format!("result={:?}", result)
-                )
-            ];
-            if let Ok(response) = result.map(|r| r.into_inner()) {
-                assertions.push(test_assert!(
-                "aggregated payload size must be 74922 bytes",
-                response.aggregated_payload_size == 74922,
-                format!("aggregated_payload_size={:?}",
-                    response.aggregated_payload_size
-                )));
-            }
-            future::ok::<Vec<TestAssertion>, Box<Error>>(assertions)
-        })
-}
-
-fn server_streaming_test(client: &mut TestClient)
-        -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
-    use pb::ResponseParameters;
-    let req = pb::StreamingOutputCallRequest {
-        response_parameters: RESPONSE_LENGTHS.iter().map(|len| {
-            ResponseParameters::with_size(*len)
-        }).collect(),
-        ..Default::default()
-    };
-    let req = Request::new(req);
-    client
-        .streaming_output_call(req)
-        .map_err(|tower_error| -> Box<Error> {
-            Box::new(tower_error)
-        })
-        .and_then(|response_stream| {
-            // Convert the stream into a plain Vec
-            response_stream.into_inner()
-                .collect()
-                .map_err(|tower_error| -> Box<Error> {
-                    Box::new(tower_error)
-                })
-        })
-        .map(|responses: Vec<pb::StreamingOutputCallResponse>| -> Vec<TestAssertion> {
-            let actual_response_lengths = response_lengths(&responses);
-            vec![
-                test_assert!(
-                    "there should be four responses",
-                    responses.len() == 4,
-                    format!("responses.len()={:?}", responses.len())
-                ),
-                test_assert!(
-                    "the response payload sizes should match input",
-                    RESPONSE_LENGTHS == actual_response_lengths.as_slice(),
-                    format!("{:?}={:?}", RESPONSE_LENGTHS, actual_response_lengths)
-                ),
-            ]
-        })
-        .then(&assert_success)
-}
+struct TestClient(
+    pb::client::TestService<tower_http::AddOrigin<
+        tower_h2::client::Connection<
+            tokio_core::net::TcpStream,
+            tokio_core::reactor::Handle,
+            tower_h2::BoxBody>>>
+);
 
 fn make_ping_pong_request(idx: usize) -> pb::StreamingOutputCallRequest {
     let req_len = REQUEST_LENGTHS[idx];
@@ -436,7 +284,8 @@ impl PingPongState {
                             }))
                     } else {
                         sender.unbounded_send(
-                            make_ping_pong_request(responses.len())).unwrap();
+                            make_ping_pong_request(responses.len())
+                        ).unwrap();
                         PingPongState {
                             sender,
                             stream,
@@ -456,71 +305,224 @@ impl PingPongState {
     }
 }
 
-fn ping_pong_test(client: &mut TestClient)
-        -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
-    let (sender, receiver) = futures::sync::mpsc::unbounded::<
-        pb::StreamingOutputCallRequest>();
+impl TestClient {
+    fn empty_unary_test(&mut self)
+            -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
+        use pb::Empty;
+        self.0.empty_call(Request::new(Empty {}))
+            .then(|result| {
+                let mut assertions = vec![
+                    test_assert!(
+                        "call must be successful",
+                        result.is_ok(),
+                        format!("result={:?}", result)
+                    )
+                ];
+                if let Ok(body) = result.map(|r| r.into_inner()) {
+                    assertions.push(test_assert!(
+                        "body must not be null",
+                        body == Empty{},
+                        format!("body={:?}", body)
+                    ))
+                }
+                future::ok::<Vec<TestAssertion>, Box<Error>>(assertions)
+            })
+    }
 
-    // Kick off the initial ping; without this the server does not
-    // even start responding.
-    sender.unbounded_send(make_ping_pong_request(0)).unwrap();
+    fn large_unary_test(&mut self)
+            -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
+        use std::mem;
+        let payload = util::client_payload(LARGE_REQ_SIZE);
+        let req = SimpleRequest {
+            response_type: pb::PayloadType::Compressable as i32,
+            response_size: LARGE_RSP_SIZE,
+            payload: Some(payload),
+            ..Default::default()
+        };
+        self.0.unary_call(Request::new(req))
+            .then(|result| {
+                let mut assertions = vec![
+                    test_assert!(
+                        "call must be successful",
+                        result.is_ok(),
+                        format!("result={:?}", result)
+                    )
+                ];
+                if let Ok(body) = result.map(|r| r.into_inner()) {
+                    let payload_len = body.payload.as_ref()
+                        .map(|p| p.body.len())
+                        .unwrap_or(0);
 
-    client
-        .full_duplex_call(Request::new(receiver
-            .map_err(|_error| panic!("Receiver stream should not error!"))))
-        .map_err(|tower_error| -> Box<Error> {
-            Box::new(tower_error)
-        })
-        .and_then(|response_stream| {
-            PingPongState {
-                sender,
-                stream: Box::new(response_stream.into_inner()),
-                responses: vec![],
-                assertions: vec![],
-            }.perform_ping_pong()
-        })
-        .map(|(responses, mut assertions)| {
-            let actual_response_lengths = response_lengths(&responses);
-            assertions.push(test_assert!(
-                "there should be four responses",
-                responses.len() == RESPONSE_LENGTHS.len(),
-                format!("{:?}={:?}", responses.len(), RESPONSE_LENGTHS.len())
-            ));
-            assertions.push(test_assert!(
-                "the response payload sizes should match input",
-                RESPONSE_LENGTHS == actual_response_lengths.as_slice(),
-                format!("{:?}={:?}", RESPONSE_LENGTHS, actual_response_lengths)
-            ));
-            assertions
-        })
-        .then(&assert_success)
-}
+                    assertions.push(test_assert!(
+                    "body must be 314159 bytes",
+                    payload_len == LARGE_RSP_SIZE as usize,
+                    format!("mem::size_of_val(&body)={:?}",
+                        mem::size_of_val(&body))
+                    ));
+                }
+                future::ok::<Vec<TestAssertion>, Box<Error>>(assertions)
+            })
+    }
 
-fn empty_stream_test(client: &mut TestClient)
-        -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
-    let stream = stream::iter_ok(Vec::<pb::StreamingOutputCallRequest>::new());
-    client.full_duplex_call(Request::new(stream))
-        .map_err(|tower_error| -> Box<Error> {
-            Box::new(tower_error)
-        })
-        .and_then(|response_stream| {
-            // Convert the stream into a plain Vec
-            response_stream.into_inner()
-                .collect()
-                .map_err(|tower_error| -> Box<Error> {
-                    Box::new(tower_error)
-                })
-        })
-        .map(|responses: Vec<pb::StreamingOutputCallResponse>| -> Vec<TestAssertion> {
-            vec![
-                test_assert!(
-                    "there should be no responses",
-                    responses.len() == 0,
-                    format!("responses.len()={:?}", responses.len())
-                ),
-            ]
-        })
-        .then(&assert_success)
+    fn cacheable_unary_test(&mut self)
+            -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
+        let payload = pb::Payload {
+            type_: pb::PayloadType::Compressable as i32,
+            body: format!("{:?}", std::time::Instant::now()).into_bytes(),
+        };
+        let req = SimpleRequest {
+            response_type: pb::PayloadType::Compressable as i32,
+            payload: Some(payload),
+            ..Default::default()
+        };
+        let mut req = Request::new(req);
+        req.headers_mut()
+            .insert(" x-user-ip", HeaderValue::from_static("1.2.3.4"));
+        // core.run(client.unary_call(req)
+        //     .then(|result| {
+        //         unimplemented!()
+        //     })
+        // )
+        unimplemented!();
+        // This line is just a hint for the type checker
+        future::ok::<Vec<TestAssertion>, Box<Error>>(vec![])
+    }
+
+    fn client_streaming_test(&mut self)
+            -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
+        let requests = REQUEST_LENGTHS
+            .iter()
+            .map(|len| StreamingInputCallRequest {
+                payload: Some(util::client_payload(*len as usize)),
+                ..Default::default()
+            });
+        let stream = stream::iter_ok(requests);
+        self.0.streaming_input_call(Request::new(stream))
+            .then(|result| {
+                let mut assertions = vec![
+                    test_assert!(
+                        "call must be successful",
+                        result.is_ok(),
+                        format!("result={:?}", result)
+                    )
+                ];
+                if let Ok(response) = result.map(|r| r.into_inner()) {
+                    assertions.push(test_assert!(
+                    "aggregated payload size must be 74922 bytes",
+                    response.aggregated_payload_size == 74922,
+                    format!("aggregated_payload_size={:?}",
+                        response.aggregated_payload_size
+                    )));
+                }
+                future::ok::<Vec<TestAssertion>, Box<Error>>(assertions)
+            })
+    }
+
+    fn server_streaming_test(&mut self)
+            -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
+        use pb::ResponseParameters;
+        let req = pb::StreamingOutputCallRequest {
+            response_parameters: RESPONSE_LENGTHS.iter().map(|len| {
+                ResponseParameters::with_size(*len)
+            }).collect(),
+            ..Default::default()
+        };
+        let req = Request::new(req);
+        self.0.streaming_output_call(req)
+            .map_err(|tower_error| -> Box<Error> {
+                Box::new(tower_error)
+            })
+            .and_then(|response_stream| {
+                // Convert the stream into a plain Vec
+                response_stream.into_inner()
+                    .collect()
+                    .map_err(|tower_error| -> Box<Error> {
+                        Box::new(tower_error)
+                    })
+            })
+            .map(|responses: Vec<pb::StreamingOutputCallResponse>| -> Vec<TestAssertion> {
+                let actual_response_lengths = response_lengths(&responses);
+                vec![
+                    test_assert!(
+                        "there should be four responses",
+                        responses.len() == 4,
+                        format!("responses.len()={:?}", responses.len())
+                    ),
+                    test_assert!(
+                        "the response payload sizes should match input",
+                        RESPONSE_LENGTHS == actual_response_lengths.as_slice(),
+                        format!("{:?}={:?}", RESPONSE_LENGTHS, actual_response_lengths)
+                    ),
+                ]
+            })
+            .then(&assert_success)
+    }
+
+    fn ping_pong_test(&mut self)
+            -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
+        let (sender, receiver) = futures::sync::mpsc::unbounded::<
+            pb::StreamingOutputCallRequest>();
+
+        // Kick off the initial ping; without this the server does not
+        // even start responding.
+        sender.unbounded_send(make_ping_pong_request(0)).unwrap();
+
+        self.0.full_duplex_call(Request::new(receiver
+                .map_err(|_error| panic!("Receiver stream should not error!"))))
+            .map_err(|tower_error| -> Box<Error> {
+                Box::new(tower_error)
+            })
+            .and_then(|response_stream| {
+                PingPongState {
+                    sender,
+                    stream: Box::new(response_stream.into_inner()),
+                    responses: vec![],
+                    assertions: vec![],
+                }.perform_ping_pong()
+            })
+            .map(|(responses, mut assertions)| {
+                let actual_response_lengths = response_lengths(&responses);
+                assertions.push(test_assert!(
+                    "there should be four responses",
+                    responses.len() == RESPONSE_LENGTHS.len(),
+                    format!("{:?}={:?}", responses.len(), RESPONSE_LENGTHS.len())
+                ));
+                assertions.push(test_assert!(
+                    "the response payload sizes should match input",
+                    RESPONSE_LENGTHS == actual_response_lengths.as_slice(),
+                    format!("{:?}={:?}", RESPONSE_LENGTHS, actual_response_lengths)
+                ));
+                assertions
+            })
+            .then(&assert_success)
+    }
+
+    fn empty_stream_test(&mut self)
+            -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
+        let stream = stream::iter_ok(Vec::<pb::StreamingOutputCallRequest>::new());
+        self.0.full_duplex_call(Request::new(stream))
+            .map_err(|tower_error| -> Box<Error> {
+                Box::new(tower_error)
+            })
+            .and_then(|response_stream| {
+                // Convert the stream into a plain Vec
+                response_stream.into_inner()
+                    .collect()
+                    .map_err(|tower_error| -> Box<Error> {
+                        Box::new(tower_error)
+                    })
+            })
+            .map(|responses: Vec<pb::StreamingOutputCallResponse>| -> Vec<TestAssertion> {
+                vec![
+                    test_assert!(
+                        "there should be no responses",
+                        responses.len() == 0,
+                        format!("responses.len()={:?}", responses.len())
+                    ),
+                ]
+            })
+            .then(&assert_success)
+    }
 }
 
 impl Testcase {
@@ -528,7 +530,7 @@ impl Testcase {
            -> Result<Vec<TestAssertion>, Box<Error>> {
 
         let reactor = core.handle();
-        let mut client = core.run(
+        let mut client = TestClient(core.run(
             TcpStream::connect(&server.addr, &reactor)
                 .and_then(move |socket| {
                     // Bind the HTTP/2.0 connection
@@ -545,23 +547,23 @@ impl Testcase {
 
                     TestService::new(conn)
                 })
-        ).expect("client");
+        ).expect("client"));
 
         match *self {
             Testcase::empty_unary =>
-                core.run(empty_unary_test(&mut client)),
+                core.run(client.empty_unary_test()),
             Testcase::large_unary =>
-                core.run(large_unary_test(&mut client)),
+                core.run(client.large_unary_test()),
             Testcase::cacheable_unary =>
-                core.run(cacheable_unary_test(&mut client)),
+                core.run(client.cacheable_unary_test()),
             Testcase::client_streaming =>
-                core.run(client_streaming_test(&mut client)),
+                core.run(client.client_streaming_test()),
             Testcase::server_streaming =>
-                core.run(server_streaming_test(&mut client)),
+                core.run(client.server_streaming_test()),
             Testcase::ping_pong =>
-                core.run(ping_pong_test(&mut client)),
+                core.run(client.ping_pong_test()),
             Testcase::empty_stream =>
-                core.run(empty_stream_test(&mut client)),
+                core.run(client.empty_stream_test()),
             Testcase::compute_engine_creds
             | Testcase::jwt_token_creds
             | Testcase::oauth2_auth_token

--- a/tower-grpc-interop/travis-interop.sh
+++ b/tower-grpc-interop/travis-interop.sh
@@ -24,4 +24,4 @@ trap 'echo ":; killing test server"; kill ${SERVER_PID};' EXIT
 
 # run the interop test client against the server.
 cargo run -p tower-grpc-interop --bin client -- \
-    --test_case=empty_unary,large_unary,client_streaming
+    --test_case=client_streaming,empty_unary,large_unary,server_streaming

--- a/tower-grpc-interop/travis-interop.sh
+++ b/tower-grpc-interop/travis-interop.sh
@@ -24,4 +24,4 @@ trap 'echo ":; killing test server"; kill ${SERVER_PID};' EXIT
 
 # run the interop test client against the server.
 cargo run -p tower-grpc-interop --bin client -- \
-    --test_case=client_streaming,empty_unary,large_unary,server_streaming
+    --test_case=client_streaming,empty_stream,empty_unary,large_unary,server_streaming

--- a/tower-grpc-interop/travis-interop.sh
+++ b/tower-grpc-interop/travis-interop.sh
@@ -24,4 +24,4 @@ trap 'echo ":; killing test server"; kill ${SERVER_PID};' EXIT
 
 # run the interop test client against the server.
 cargo run -p tower-grpc-interop --bin client -- \
-    --test_case=client_streaming,empty_stream,empty_unary,large_unary,server_streaming
+    --test_case=client_streaming,empty_stream,empty_unary,large_unary,ping_pong,server_streaming


### PR DESCRIPTION
# server_streaming

The server_streaming test case is based on Eliza's work in #49.

When reviewing, please check if what I'm doing in `error.rs` is the idiomatic thing to do, I'm unsure. I could also do this without making the `Error` type implement `std::error::Error` but that would probably involve either messing around with refcounted assertion error lists or explicit stringing through of the errors, which would reduce readability. Another approach could be to refactor the tests to use a non-functional approach where assertions are side effectful.

I'm not sure how to best format the code for readability here. I added some non-mandatory type annotations in an attempt to make the code easier to follow, not sure what's the best practice is here

# ping_pong

The code for this test case is really not that easy to read. Besides using async/await syntax and/or fixing the error types in tower-grpc to be simpler and more unified I don't know how to write the code in a simpler way.

# Misc

Note: This will conflict with #71 so perhaps merge that first and let me resolve the conflict before reviewing this.

Fixes #49, #23.