### PR TITLE
Adding custom metadata in helloworld client example

### DIFF
--- a/tower-grpc-examples/Cargo.toml
+++ b/tower-grpc-examples/Cargo.toml
@@ -12,6 +12,14 @@ name = "helloworld-client"
 path = "src/helloworld/client.rs"
 
 [[bin]]
+name = "metadata-server"
+path = "src/metadata/server.rs"
+
+[[bin]]
+name = "metadata-client"
+path = "src/metadata/client.rs"
+
+[[bin]]
 name = "route-guide-server"
 path = "src/routeguide/server.rs"
 

--- a/tower-grpc-examples/build.rs
+++ b/tower-grpc-examples/build.rs
@@ -8,6 +8,13 @@ fn main() {
         .build(&["proto/helloworld/helloworld.proto"], &["proto/helloworld"])
         .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
 
+    // Build metadata
+    tower_grpc_build::Config::new()
+        .enable_server(true)
+        .enable_client(true)
+        .build(&["proto/metadata/metadata.proto"], &["proto/metadata"])
+        .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
+
     // Build routeguide
     tower_grpc_build::Config::new()
         .enable_server(true)

--- a/tower-grpc-examples/proto/metadata/metadata.proto
+++ b/tower-grpc-examples/proto/metadata/metadata.proto
@@ -1,0 +1,37 @@
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.metadata";
+option java_outer_classname = "MetadataProto";
+
+package metadata;
+
+// The doorman service definition.
+service Doorman {
+  // Ask for permission to enter
+  rpc AskToEnter (EnterRequest) returns (EnterReply) {}
+}
+
+// The request message containing a greeting.
+message EnterRequest {
+  string message = 1;
+}
+
+// The response message containing approval to enter
+message EnterReply {
+  string message = 1;
+}

--- a/tower-grpc-examples/src/metadata/client.rs
+++ b/tower-grpc-examples/src/metadata/client.rs
@@ -1,0 +1,70 @@
+extern crate bytes;
+extern crate env_logger;
+extern crate http;
+extern crate futures;
+extern crate log;
+extern crate prost;
+#[macro_use]
+extern crate prost_derive;
+extern crate tokio_core;
+extern crate tower_h2;
+extern crate tower_http;
+extern crate tower_grpc;
+
+use futures::Future;
+use tokio_core::reactor::Core;
+use tokio_core::net::TcpStream;
+use tower_grpc::Request;
+use tower_h2::client::Connection;
+
+pub mod metadata {
+    include!(concat!(env!("OUT_DIR"), "/metadata.rs"));
+}
+
+pub fn main() {
+    let _ = ::env_logger::init();
+
+    let mut core = Core::new().unwrap();
+    let reactor = core.handle();
+
+    let addr = "[::1]:50051".parse().unwrap();
+    let uri: http::Uri = format!("http://localhost:50051").parse().unwrap();
+
+    let say_hello = TcpStream::connect(&addr, &reactor)
+        .and_then(move |socket| {
+            // Bind the HTTP/2.0 connection
+            Connection::handshake(socket, reactor)
+                .map_err(|_| panic!("failed HTTP/2.0 handshake"))
+        })
+        .map(move |conn| {
+            use metadata::client::Doorman;
+            use tower_http::add_origin;
+
+            let conn = add_origin::Builder::new()
+                .uri(uri)
+                .build(conn)
+                .unwrap();
+
+            Doorman::new(conn)
+        })
+        .and_then(|mut client| {
+            use metadata::EnterRequest;
+
+            let mut request = Request::new(EnterRequest {
+                message: "Hello! Can I come in?".to_string(),
+            });
+
+            request.headers_mut().insert("metadata", "Here is a cookie".parse().unwrap());
+
+            client.ask_to_enter(request).map_err(|e| panic!("gRPC request failed; err={:?}", e))
+        })
+        .and_then(|response| {
+            println!("RESPONSE = {:?}", response);
+            Ok(())
+        })
+        .map_err(|e| {
+            println!("ERR = {:?}", e);
+        });
+
+    core.run(say_hello).unwrap();
+}

--- a/tower-grpc-examples/src/metadata/server.rs
+++ b/tower-grpc-examples/src/metadata/server.rs
@@ -1,0 +1,78 @@
+extern crate bytes;
+extern crate env_logger;
+extern crate futures;
+#[macro_use]
+extern crate log;
+extern crate prost;
+#[macro_use]
+extern crate prost_derive;
+extern crate http;
+extern crate tokio_core;
+extern crate tower_grpc;
+extern crate tower_h2;
+
+pub mod metadata {
+    include!(concat!(env!("OUT_DIR"), "/metadata.rs"));
+}
+
+use metadata::{server, EnterReply, EnterRequest};
+
+use futures::{future, Future, Stream};
+use tokio_core::net::TcpListener;
+use tokio_core::reactor::Core;
+use tower_grpc::{Request, Response};
+use tower_h2::Server;
+
+#[derive(Clone, Debug)]
+struct Door;
+
+impl server::Doorman for Door {
+    type AskToEnterFuture = future::FutureResult<Response<EnterReply>, tower_grpc::Error>;
+
+    fn ask_to_enter(&mut self, request: Request<EnterRequest>) -> Self::AskToEnterFuture {
+        println!("REQUEST = {:?}", request);
+
+        let metadata = request
+            .headers()
+            .get("metadata")
+            .and_then(|header| header.to_str().ok());
+
+        let message = match metadata {
+            Some("Here is a cookie") => "Yummy! Please come in.".to_string(),
+            _ => "You cannot come in!".to_string(),
+        };
+
+        let response = Response::new(EnterReply { message });
+
+        future::ok(response)
+    }
+}
+
+pub fn main() {
+    let _ = ::env_logger::init();
+
+    let mut core = Core::new().unwrap();
+    let reactor = core.handle();
+
+    let new_service = server::DoormanServer::new(Door);
+
+    let h2 = Server::new(new_service, Default::default(), reactor.clone());
+
+    let addr = "[::1]:50051".parse().unwrap();
+    let bind = TcpListener::bind(&addr, &reactor).expect("bind");
+
+    let serve = bind
+        .incoming()
+        .fold((h2, reactor), |(h2, reactor), (sock, _)| {
+            if let Err(e) = sock.set_nodelay(true) {
+                return Err(e);
+            }
+
+            let serve = h2.serve(sock);
+            reactor.spawn(serve.map_err(|e| error!("h2 error: {:?}", e)));
+
+            Ok((h2, reactor))
+        });
+
+    core.run(serve).unwrap();
+}


### PR DESCRIPTION
In relation to #79. While it may be straightforward to some that gRPC metadata can directly be set as custom headers in the HTTP2 layer, it was not to me.

I think that adding it in the example may be useful to some until the `metadata` check box is ticked.