### PR TITLE
Introduce tower_grpc::metadata::MetadataMap type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,13 +34,11 @@ pub use status::{Code, Status};
 pub use request::Request;
 pub use response::Response;
 
+/// The metadata module contains data structures and utilities for handling
+/// gRPC custom metadata.
 pub mod metadata {
     pub use metadata_key::MetadataKey;
-    pub use metadata_key::InvalidMetadataKey;
     pub use metadata_value::MetadataValue;
-    pub use metadata_value::InvalidMetadataValue;
-    pub use metadata_value::InvalidMetadataValueBytes;
-    pub use metadata_value::ToStrError;
     pub use metadata_map::MetadataMap;
     pub use metadata_map::Iter;
     pub use metadata_map::ValueDrain;
@@ -52,6 +50,15 @@ pub mod metadata {
     pub use metadata_map::Entry;
     pub use metadata_map::VacantEntry;
     pub use metadata_map::OccupiedEntry;
+
+    /// The metadata::errors module contains types for errors that can occur
+    /// while handling gRPC custom metadata.
+    pub mod errors {
+        pub use metadata_key::InvalidMetadataKey;
+        pub use metadata_value::InvalidMetadataValue;
+        pub use metadata_value::InvalidMetadataValueBytes;
+        pub use metadata_value::ToStrError;
+    }
 }
 
 #[cfg(feature = "protobuf")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@ pub mod client;
 pub mod generic;
 
 mod error;
+mod metadata_key;
+mod metadata_value;
+mod metadata_map;
 mod request;
 mod response;
 mod status;
@@ -26,6 +29,26 @@ pub use error::{Error, ProtocolError};
 pub use status::{Code, Status};
 pub use request::Request;
 pub use response::Response;
+
+pub mod metadata {
+    pub use metadata_key::MetadataKey;
+    pub use metadata_key::InvalidMetadataKey;
+    pub use metadata_value::MetadataValue;
+    pub use metadata_value::InvalidMetadataValue;
+    pub use metadata_value::InvalidMetadataValueBytes;
+    pub use metadata_value::ToStrError;
+    pub use metadata_map::MetadataMap;
+    pub use metadata_map::Iter;
+    pub use metadata_map::ValueDrain;
+    pub use metadata_map::Drain;
+    pub use metadata_map::Keys;
+    pub use metadata_map::Values;
+    pub use metadata_map::ValueIter;
+    pub use metadata_map::GetAll;
+    pub use metadata_map::Entry;
+    pub use metadata_map::VacantEntry;
+    pub use metadata_map::OccupiedEntry;
+}
 
 #[cfg(feature = "protobuf")]
 pub mod server;

--- a/src/metadata_key.rs
+++ b/src/metadata_key.rs
@@ -34,31 +34,6 @@ impl MetadataKey {
         }
     }
 
-    /// Converts a slice of bytes to a `MetadataKey`.
-    ///
-    /// This function expects the input to only contain lowercase characters.
-    /// This is useful when decoding HTTP/2.0 headers. The HTTP/2.0
-    /// specification requires that all headers be represented in lower case.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use tower_grpc::metadata::*;
-    ///
-    /// // Parsing a lower case metadata key
-    /// let hdr = MetadataKey::from_lowercase(b"content-length").unwrap();
-    /// assert_eq!("content-length", hdr);
-    ///
-    /// // Parsing a metadata key that contains uppercase characters
-    /// assert!(MetadataKey::from_lowercase(b"Content-Length").is_err());
-    /// ```
-    pub fn from_lowercase(src: &[u8]) -> Result<MetadataKey, InvalidMetadataKey> {
-        match HeaderName::from_lowercase(src) {
-            Ok(name) => Ok(MetadataKey { inner: name }),
-            Err(_) => Err(InvalidMetadataKey { _priv: () })
-        }
-    }
-
     /// Converts a static string to a `MetadataKey`.
     ///
     /// This function panics when the static string is a invalid metadata key.
@@ -75,7 +50,7 @@ impl MetadataKey {
     /// // Parsing a metadata key
     /// let CUSTOM_KEY: &'static str = "custom-key";
     /// 
-    /// let a = MetadataKey::from_lowercase(b"custom-key").unwrap();
+    /// let a = MetadataKey::from_bytes(b"custom-key").unwrap();
     /// let b = MetadataKey::from_static(CUSTOM_KEY);
     /// assert_eq!(a, b);
     /// ```

--- a/src/metadata_key.rs
+++ b/src/metadata_key.rs
@@ -1,0 +1,249 @@
+use bytes::Bytes;
+use http;
+use http::header::HeaderName;
+
+use std::borrow::Borrow;
+use std::error::Error;
+use std::fmt;
+use std::str::FromStr;
+
+/// Represents a custom metadata field name.
+///
+/// `MetadataKey` is used as the [`MetadataMap`] key.
+///
+/// [`HeaderMap`]: struct.HeaderMap.html
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub struct MetadataKey {
+    pub(crate) inner: http::header::HeaderName,
+}
+
+/// A possible error when converting a `MetadataKey` from another type.
+#[derive(Debug)]
+pub struct InvalidMetadataKey {
+    _priv: (),
+}
+
+impl MetadataKey {
+    /// Converts a slice of bytes to a `MetadataKey`.
+    ///
+    /// This function normalizes the input.
+    pub fn from_bytes(src: &[u8]) -> Result<MetadataKey, InvalidMetadataKey> {
+        match HeaderName::from_bytes(src) {
+            Ok(name) => Ok(MetadataKey { inner: name }),
+            Err(_) => Err(InvalidMetadataKey::new())
+        }
+    }
+
+    /// Converts a slice of bytes to a `MetadataKey`.
+    ///
+    /// This function expects the input to only contain lowercase characters.
+    /// This is useful when decoding HTTP/2.0 headers. The HTTP/2.0
+    /// specification requires that all headers be represented in lower case.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    ///
+    /// // Parsing a lower case metadata key
+    /// let hdr = MetadataKey::from_lowercase(b"content-length").unwrap();
+    /// assert_eq!("content-length", hdr);
+    ///
+    /// // Parsing a metadata key that contains uppercase characters
+    /// assert!(MetadataKey::from_lowercase(b"Content-Length").is_err());
+    /// ```
+    pub fn from_lowercase(src: &[u8]) -> Result<MetadataKey, InvalidMetadataKey> {
+        match HeaderName::from_lowercase(src) {
+            Ok(name) => Ok(MetadataKey { inner: name }),
+            Err(_) => Err(InvalidMetadataKey { _priv: () })
+        }
+    }
+
+    /// Converts a static string to a `MetadataKey`.
+    ///
+    /// This function panics when the static string is a invalid metadata key.
+    /// 
+    /// This function requires the static string to only contain lowercase 
+    /// characters, numerals and symbols, as per the HTTP/2.0 specification 
+    /// and header names internal representation within this library.
+    /// 
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// // Parsing a metadata key
+    /// let CUSTOM_KEY: &'static str = "custom-key";
+    /// 
+    /// let a = MetadataKey::from_lowercase(b"custom-key").unwrap();
+    /// let b = MetadataKey::from_static(CUSTOM_KEY);
+    /// assert_eq!(a, b);
+    /// ```
+    /// 
+    /// ```should_panic
+    /// # use tower_grpc::metadata::*;
+    /// #
+    /// // Parsing a metadata key that contains invalid symbols(s):
+    /// MetadataKey::from_static("content{}{}length"); // This line panics!
+    /// 
+    /// // Parsing a metadata key that contains invalid uppercase characters.
+    /// let a = MetadataKey::from_static("foobar");
+    /// let b = MetadataKey::from_static("FOOBAR"); // This line panics!
+    /// ```
+    pub fn from_static(src: &'static str) -> MetadataKey {
+        MetadataKey { inner: HeaderName::from_static(src) }
+    }
+
+    /// Returns a `str` representation of the metadata key.
+    ///
+    /// The returned string will always be lower case.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        self.inner.as_str()
+    }
+}
+
+impl FromStr for MetadataKey {
+    type Err = InvalidMetadataKey;
+
+    fn from_str(s: &str) -> Result<MetadataKey, InvalidMetadataKey> {
+        MetadataKey::from_bytes(s.as_bytes())
+            .map_err(|_| InvalidMetadataKey::new())
+    }
+}
+
+impl AsRef<str> for MetadataKey {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<[u8]> for MetadataKey {
+    fn as_ref(&self) -> &[u8] {
+        self.as_str().as_bytes()
+    }
+}
+
+impl Borrow<str> for MetadataKey {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Debug for MetadataKey {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self.as_str(), fmt)
+    }
+}
+
+impl fmt::Display for MetadataKey {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self.as_str(), fmt)
+    }
+}
+
+impl InvalidMetadataKey {
+    pub fn new() -> InvalidMetadataKey {
+        InvalidMetadataKey { _priv: () }
+    }
+}
+
+impl<'a> From<&'a MetadataKey> for MetadataKey {
+    fn from(src: &'a MetadataKey) -> MetadataKey {
+        src.clone()
+    }
+}
+
+impl From<MetadataKey> for Bytes {
+    #[inline]
+    fn from(name: MetadataKey) -> Bytes {
+        name.inner.into()
+    }
+}
+
+impl<'a> PartialEq<&'a MetadataKey> for MetadataKey {
+    #[inline]
+    fn eq(&self, other: &&'a MetadataKey) -> bool {
+        *self == **other
+    }
+}
+
+
+impl<'a> PartialEq<MetadataKey> for &'a MetadataKey {
+    #[inline]
+    fn eq(&self, other: &MetadataKey) -> bool {
+        *other == *self
+    }
+}
+
+impl PartialEq<str> for MetadataKey {
+    /// Performs a case-insensitive comparison of the string against the header
+    /// name
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let content_length = MetadataKey::from_static("content-length");
+    ///
+    /// assert_eq!(content_length, "content-length");
+    /// assert_eq!(content_length, "Content-Length");
+    /// assert_ne!(content_length, "content length");
+    /// ```
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        self.inner.eq(other)
+    }
+}
+
+
+impl PartialEq<MetadataKey> for str {
+    /// Performs a case-insensitive comparison of the string against the header
+    /// name
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let content_length = MetadataKey::from_static("content-length");
+    ///
+    /// assert_eq!(content_length, "content-length");
+    /// assert_eq!(content_length, "Content-Length");
+    /// assert_ne!(content_length, "content length");
+    /// ```
+    #[inline]
+    fn eq(&self, other: &MetadataKey) -> bool {
+        (*other).inner == *self
+    }
+}
+
+impl<'a> PartialEq<&'a str> for MetadataKey {
+    /// Performs a case-insensitive comparison of the string against the header
+    /// name
+    #[inline]
+    fn eq(&self, other: &&'a str) -> bool {
+        *self == **other
+    }
+}
+
+
+impl<'a> PartialEq<MetadataKey> for &'a str {
+    /// Performs a case-insensitive comparison of the string against the header
+    /// name
+    #[inline]
+    fn eq(&self, other: &MetadataKey) -> bool {
+        *other == *self
+    }
+}
+
+impl fmt::Display for InvalidMetadataKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.description().fmt(f)
+    }
+}
+
+impl Error for InvalidMetadataKey {
+    fn description(&self) -> &str {
+        "invalid gRPC metadata key name"
+    }
+}

--- a/src/metadata_key.rs
+++ b/src/metadata_key.rs
@@ -13,6 +13,7 @@ use std::str::FromStr;
 ///
 /// [`HeaderMap`]: struct.HeaderMap.html
 #[derive(Clone, Eq, PartialEq, Hash)]
+#[repr(transparent)]
 pub struct MetadataKey {
     // Note: There are unsafe transmutes that assume that the memory layout
     // of MetadataValue is identical to HeaderName

--- a/src/metadata_key.rs
+++ b/src/metadata_key.rs
@@ -14,6 +14,8 @@ use std::str::FromStr;
 /// [`HeaderMap`]: struct.HeaderMap.html
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct MetadataKey {
+    // Note: There are unsafe transmutes that assume that the memory layout
+    // of MetadataValue is identical to HeaderName
     pub(crate) inner: http::header::HeaderName,
 }
 
@@ -75,6 +77,11 @@ impl MetadataKey {
     #[inline]
     pub fn as_str(&self) -> &str {
         self.inner.as_str()
+    }
+
+    #[inline]
+    pub(crate) fn from_header_name(header_name: &HeaderName) -> &Self {
+        unsafe { &*(header_name as *const HeaderName as *const Self) }
     }
 }
 

--- a/src/metadata_map.rs
+++ b/src/metadata_map.rs
@@ -1,0 +1,1716 @@
+use http;
+use metadata_key::InvalidMetadataKey;
+use metadata_key::MetadataKey;
+use metadata_value::MetadataValue;
+
+pub use self::as_metadata_key::AsMetadataKey;
+pub use self::into_metadata_key::IntoMetadataKey;
+
+/// A set of gRPC custom metadata entries.
+///
+/// # Examples
+///
+/// Basic usage
+///
+/// ```
+/// # use tower_grpc::metadata::*;
+/// let mut map = MetadataMap::new();
+///
+/// map.insert("x-host", "example.com".parse().unwrap());
+/// map.insert("x-number", "123".parse().unwrap());
+///
+/// assert!(map.contains_key("x-host"));
+/// assert!(!map.contains_key("x-location"));
+///
+/// assert_eq!(map.get("x-host").unwrap(), "example.com");
+///
+/// map.remove("x-host");
+///
+/// assert!(!map.contains_key("x-host"));
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct MetadataMap {
+    headers: http::HeaderMap<MetadataValue>,
+}
+
+/// `HeaderMap` entry iterator.
+///
+/// Yields `(&HeaderName, &value)` tuples. The same header name may be yielded
+/// more than once if it has more than one associated value.
+#[derive(Debug)]
+pub struct Iter<'a, T: 'a> {
+    inner: http::header::Iter<'a, T>,
+}
+
+/// A drain iterator of all values associated with a single metadata key.
+#[derive(Debug)]
+pub struct ValueDrain<'a, T: 'a> {
+    inner: http::header::ValueDrain<'a, T>,
+}
+
+/// A drain iterator for `MetadataMap`.
+#[derive(Debug)]
+pub struct Drain<'a, T: 'a> {
+    inner: http::header::Drain<'a, T>,
+}
+
+/// An iterator over `MetadataMap` keys.
+///
+/// Each header name is yielded only once, even if it has more than one
+/// associated value.
+#[derive(Debug)]
+pub struct Keys<'a, T: 'a> {
+    inner: http::header::Keys<'a, T>,
+}
+
+/// `MetadataMap` value iterator.
+///
+/// Each value contained in the `MetadataMap` will be yielded.
+#[derive(Debug)]
+pub struct Values<'a, T: 'a> {
+    inner: http::header::Values<'a, T>,
+}
+
+/// An iterator of all values associated with a single metadata key.
+#[derive(Debug)]
+pub struct ValueIter<'a, T: 'a> {
+    inner: http::header::ValueIter<'a, T>,
+}
+
+/// An iterator of all values associated with a single metadata key.
+#[derive(Debug)]
+pub struct ValueIterMut<'a, T: 'a> {
+    inner: http::header::ValueIterMut<'a, T>,
+}
+
+/// A view to all values stored in a single entry.
+///
+/// This struct is returned by `MetadataMap::get_all`.
+#[derive(Debug)]
+pub struct GetAll<'a> {
+    inner: http::header::GetAll<'a, MetadataValue>
+}
+
+/// A view into a single location in a `MetadataMap`, which may be vacant or occupied.
+#[derive(Debug)]
+pub enum Entry<'a, T: 'a> {
+    /// An occupied entry
+    Occupied(OccupiedEntry<'a, T>),
+
+    /// A vacant entry
+    Vacant(VacantEntry<'a, T>),
+}
+
+/// A view into a single empty location in a `MetadataMap`.
+///
+/// This struct is returned as part of the `Entry` enum.
+#[derive(Debug)]
+pub struct VacantEntry<'a, T: 'a> {
+    inner: http::header::VacantEntry<'a, T>,
+}
+
+/// A view into a single occupied location in a `MetadataMap`.
+///
+/// This struct is returned as part of the `Entry` enum.
+#[derive(Debug)]
+pub struct OccupiedEntry<'a, T: 'a> {
+    inner: http::header::OccupiedEntry<'a, T>,
+}
+
+// ===== impl MetadataMap =====
+
+impl MetadataMap {
+    /// Create an empty `MetadataMap`.
+    ///
+    /// The map will be created without any capacity. This function will not
+    /// allocate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let map = MetadataMap::new();
+    ///
+    /// assert!(map.is_empty());
+    /// assert_eq!(0, map.capacity());
+    /// ```
+    pub fn new() -> Self {
+        MetadataMap::with_capacity(0)
+    }
+
+    /// Convert an HTTP HeaderMap to a MetadataMap
+    pub fn from_headers(mut headers: http::HeaderMap) -> Self {
+        let mut map = Self::with_capacity(headers.len());
+        for (name, values) in headers.drain() {
+            let key = MetadataKey { inner: name };
+            for value in values {
+                map.append(&key, MetadataValue { inner: value });
+            }
+        }
+        map
+    }
+
+    /// Convert a MetadataMap into a HTTP HeaderMap
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// map.insert("x-host", "example.com".parse().unwrap());
+    ///
+    /// let http_map = map.into_headers();
+    ///
+    /// assert_eq!(http_map.get("x-host").unwrap(), "example.com");
+    /// ```
+    pub fn into_headers(mut self) -> http::HeaderMap {
+        let mut map = http::HeaderMap::with_capacity(self.len());
+        for (key, values) in self.drain() {
+            for value in values {
+                map.append(&key.inner, value.inner);
+            }
+        }
+        map
+    }
+
+    /// Create an empty `MetadataMap` with the specified capacity.
+    ///
+    /// The returned map will allocate internal storage in order to hold about
+    /// `capacity` elements without reallocating. However, this is a "best
+    /// effort" as there are usage patterns that could cause additional
+    /// allocations before `capacity` metadata entries are stored in the map.
+    ///
+    /// More capacity than requested may be allocated.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let map: MetadataMap = MetadataMap::with_capacity(10);
+    ///
+    /// assert!(map.is_empty());
+    /// assert!(map.capacity() >= 10);
+    /// ```
+    pub fn with_capacity(capacity: usize) -> MetadataMap {
+        MetadataMap {
+            headers: http::HeaderMap::with_capacity(capacity),
+        }
+    }
+
+    /// Returns the number of metadata entries stored in the map.
+    ///
+    /// This number represents the total number of **values** stored in the map.
+    /// This number can be greater than or equal to the number of **keys**
+    /// stored given that a single key may have more than one associated value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    ///
+    /// assert_eq!(0, map.len());
+    ///
+    /// map.insert("x-host-ip", "127.0.0.1".parse().unwrap());
+    /// map.insert("x-host-name", "localhost".parse().unwrap());
+    ///
+    /// assert_eq!(2, map.len());
+    ///
+    /// map.append("x-mime-type", "text/html".parse().unwrap());
+    ///
+    /// assert_eq!(3, map.len());
+    /// ```
+    pub fn len(&self) -> usize {
+        self.headers.len()
+    }
+
+    /// Returns the number of keys stored in the map.
+    ///
+    /// This number will be less than or equal to `len()` as each key may have
+    /// more than one associated value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    ///
+    /// assert_eq!(0, map.keys_len());
+    ///
+    /// map.insert("x-mime", "text/plain".parse().unwrap());
+    /// map.insert("x-host", "localhost".parse().unwrap());
+    ///
+    /// assert_eq!(2, map.keys_len());
+    ///
+    /// map.insert("x-mime", "text/html".parse().unwrap());
+    ///
+    /// assert_eq!(2, map.keys_len());
+    /// ```
+    pub fn keys_len(&self) -> usize {
+        self.headers.len()
+    }
+
+    /// Returns true if the map contains no elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    ///
+    /// assert!(map.is_empty());
+    ///
+    /// map.insert("x-host", "hello.world".parse().unwrap());
+    ///
+    /// assert!(!map.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.headers.is_empty()
+    }
+
+    /// Clears the map, removing all key-value pairs. Keeps the allocated memory
+    /// for reuse.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// map.insert("x-host", "hello.world".parse().unwrap());
+    ///
+    /// map.clear();
+    /// assert!(map.is_empty());
+    /// assert!(map.capacity() > 0);
+    /// ```
+    pub fn clear(&mut self) {
+        self.headers.clear();
+    }
+
+    /// Returns the number of custom metadata entries the map can hold without
+    /// reallocating.
+    ///
+    /// This number is an approximation as certain usage patterns could cause
+    /// additional allocations before the returned capacity is filled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    ///
+    /// assert_eq!(0, map.capacity());
+    ///
+    /// map.insert("x-host", "hello.world".parse().unwrap());
+    /// assert_eq!(6, map.capacity());
+    /// ```
+    pub fn capacity(&self) -> usize {
+        self.headers.capacity()
+    }
+
+    /// Reserves capacity for at least `additional` more custom metadata to be
+    /// inserted into the `MetadataMap`.
+    ///
+    /// The metadata map may reserve more space to avoid frequent reallocations.
+    /// Like with `with_capacity`, this will be a "best effort" to avoid
+    /// allocations until `additional` more custom metadata is inserted. Certain
+    /// usage patterns could cause additional allocations before the number is
+    /// reached.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new allocation size overflows `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// map.reserve(10);
+    /// # map.insert("x-host", "bar".parse().unwrap());
+    /// ```
+    pub fn reserve(&mut self, additional: usize) {
+        self.headers.reserve(additional);
+    }
+
+    /// Returns a reference to the value associated with the key.
+    ///
+    /// If there are multiple values associated with the key, then the first one
+    /// is returned. Use `get_all` to get all values associated with a given
+    /// key. Returns `None` if there are no values associated with the key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// assert!(map.get("x-host").is_none());
+    ///
+    /// map.insert("x-host", "hello".parse().unwrap());
+    /// assert_eq!(map.get("x-host").unwrap(), &"hello");
+    /// assert_eq!(map.get("x-host").unwrap(), &"hello");
+    ///
+    /// map.append("x-host", "world".parse().unwrap());
+    /// assert_eq!(map.get("x-host").unwrap(), &"hello");
+    /// ```
+    pub fn get<K>(&self, key: K) -> Option<&MetadataValue>
+        where K: AsMetadataKey
+    {
+
+        key.get(self)
+    }
+
+    /// Returns a mutable reference to the value associated with the key.
+    ///
+    /// If there are multiple values associated with the key, then the first one
+    /// is returned. Use `entry` to get all values associated with a given
+    /// key. Returns `None` if there are no values associated with the key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::default();
+    /// map.insert("x-host", "hello".parse().unwrap());
+    /// map.get_mut("x-host").unwrap().set_sensitive(true);
+    ///
+    /// assert!(map.get("x-host").unwrap().is_sensitive());
+    /// ```
+    pub fn get_mut<K>(&mut self, key: K) -> Option<&mut MetadataValue>
+        where K: AsMetadataKey
+    {
+        key.get_mut(self)
+    }
+
+    /// Returns a view of all values associated with a key.
+    ///
+    /// The returned view does not incur any allocations and allows iterating
+    /// the values associated with the key.  See [`GetAll`] for more details.
+    /// Returns `None` if there are no values associated with the key.
+    ///
+    /// [`GetAll`]: struct.GetAll.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    ///
+    /// map.insert("x-host", "hello".parse().unwrap());
+    /// map.append("x-host", "goodbye".parse().unwrap());
+    ///
+    /// let view = map.get_all("x-host");
+    ///
+    /// let mut iter = view.iter();
+    /// assert_eq!(&"hello", iter.next().unwrap());
+    /// assert_eq!(&"goodbye", iter.next().unwrap());
+    /// assert!(iter.next().is_none());
+    /// ```
+    pub fn get_all<K>(&self, key: K) -> GetAll
+        where K: AsMetadataKey
+    {
+        GetAll {
+            inner: key.get_all(self),
+        }
+    }
+
+    /// Returns true if the map contains a value for the specified key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// assert!(!map.contains_key("x-host"));
+    ///
+    /// map.insert("x-host", "world".parse().unwrap());
+    /// assert!(map.contains_key("x-host"));
+    /// ```
+    pub fn contains_key<K>(&self, key: K) -> bool
+        where K: AsMetadataKey
+    {
+        key.contains_key(self)
+    }
+
+    /// An iterator visiting all key-value pairs.
+    ///
+    /// The iteration order is arbitrary, but consistent across platforms for
+    /// the same crate version. Each key will be yielded once per associated
+    /// value. So, if a key has 3 associated values, it will be yielded 3 times.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    ///
+    /// map.insert("x-word", "hello".parse().unwrap());
+    /// map.append("x-word", "goodbye".parse().unwrap());
+    /// map.insert("x-number", "123".parse().unwrap());
+    ///
+    /// for (key, value) in map.iter() {
+    ///     println!("{:?}: {:?}", key, value);
+    /// }
+    /// ```
+    pub fn iter(&self) -> Iter<MetadataValue> {
+        Iter { inner: self.headers.iter() }
+    }
+
+    /*
+    /// An iterator visiting all key-value pairs, with mutable value references.
+    ///
+    /// The iterator order is arbitrary, but consistent across platforms for the
+    /// same crate version. Each key will be yielded once per associated value,
+    /// so if a key has 3 associated values, it will be yielded 3 times.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::default();
+    ///
+    /// map.insert("x-word", "hello".parse().unwrap());
+    /// map.append("x-word", "goodbye".parse().unwrap());
+    /// map.insert("x-number", "123".parse().unwrap());
+    ///
+    /// for (key, value) in map.iter_mut() {
+    ///     value.set_sensitive(true);
+    /// }
+    /// ```
+    // TODO(pgron): Expose this. Blocked by https://github.com/hyperium/http/pull/278
+    pub fn iter_mut(&mut self) -> http::header::map::IterMut<MetadataValue> {
+        self.headers.iter_mut()
+    }*/
+
+    /// An iterator visiting all keys.
+    ///
+    /// The iteration order is arbitrary, but consistent across platforms for
+    /// the same crate version. Each key will be yielded only once even if it
+    /// has multiple associated values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    ///
+    /// map.insert("x-word", "hello".parse().unwrap());
+    /// map.append("x-word", "goodbye".parse().unwrap());
+    /// map.insert("x-number", "123".parse().unwrap());
+    ///
+    /// for key in map.keys() {
+    ///     println!("{:?}", key);
+    /// }
+    /// ```
+    pub fn keys(&self) -> Keys<MetadataValue> {
+        Keys { inner: self.headers.keys() }
+    }
+
+    /// An iterator visiting all values.
+    ///
+    /// The iteration order is arbitrary, but consistent across platforms for
+    /// the same crate version.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    ///
+    /// map.insert("x-word", "hello".parse().unwrap());
+    /// map.append("x-word", "goodbye".parse().unwrap());
+    /// map.insert("x-number", "123".parse().unwrap());
+    ///
+    /// for value in map.values() {
+    ///     println!("{:?}", value);
+    /// }
+    /// ```
+    pub fn values(&self) -> Values<MetadataValue> {
+        Values { inner: self.headers.values() }
+    }
+
+/*
+    /// An iterator visiting all values mutably.
+    ///
+    /// The iteration order is arbitrary, but consistent across platforms for
+    /// the same crate version.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::default();
+    ///
+    /// map.insert("x-word", "hello".parse().unwrap());
+    /// map.append("x-word", "goodbye".parse().unwrap());
+    /// map.insert("x-number", "123".parse().unwrap());
+    ///
+    /// for value in map.values_mut() {
+    ///     value.set_sensitive(true);
+    /// }
+    /// ```
+    // TODO(pgron): Expose this. Blocked by https://github.com/hyperium/http/pull/278
+    pub fn values_mut(&mut self) -> http::header::ValuesMut<MetadataValue> {
+        self.headers.values_mut()
+    }*/
+
+    /// Clears the map, returning all entries as an iterator.
+    ///
+    /// The internal memory is kept for reuse.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    ///
+    /// map.insert("x-word", "hello".parse().unwrap());
+    /// map.append("x-word", "goodbye".parse().unwrap());
+    /// map.insert("x-number", "123".parse().unwrap());
+    ///
+    /// let mut drain = map.drain();
+    ///
+    /// let (key, mut vals) = drain.next().unwrap();
+    ///
+    /// assert_eq!("x-word", key);
+    /// assert_eq!("hello", vals.next().unwrap());
+    /// assert_eq!("goodbye", vals.next().unwrap());
+    /// assert!(vals.next().is_none());
+    ///
+    /// let (key, mut vals) = drain.next().unwrap();
+    ///
+    /// assert_eq!("x-number", key);
+    /// assert_eq!("123", vals.next().unwrap());
+    /// assert!(vals.next().is_none());
+    /// ```
+    pub fn drain(&mut self) -> Drain<MetadataValue> {
+        Drain { inner: self.headers.drain() }
+    }
+
+    /// Gets the given key's corresponding entry in the map for in-place
+    /// manipulation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::default();
+    ///
+    /// let headers = &[
+    ///     "content-length",
+    ///     "x-hello",
+    ///     "Content-Length",
+    ///     "x-world",
+    /// ];
+    ///
+    /// for &header in headers {
+    ///     let counter = map.entry(header).unwrap().or_insert("".parse().unwrap());
+    ///     *counter = format!("{}{}", counter.to_str().unwrap(), "1").parse().unwrap();
+    /// }
+    ///
+    /// assert_eq!(map.get("content-length").unwrap(), "11");
+    /// assert_eq!(map.get("x-hello").unwrap(), "1");
+    /// ```
+    pub fn entry<K>(&mut self, key: K) -> Result<Entry<MetadataValue>, InvalidMetadataKey>
+        where K: AsMetadataKey
+    {
+        match key.entry(self) {
+            Ok(entry) => {
+                Ok(match entry {
+                    http::header::Entry::Occupied(e) =>
+                        Entry::Occupied(OccupiedEntry { inner: e }),
+                    http::header::Entry::Vacant(e) =>
+                        Entry::Vacant(VacantEntry { inner: e }),
+                })
+            }
+            Err(_) => Err(InvalidMetadataKey::new()),
+        }
+    }
+
+    /// Inserts a key-value pair into the map.
+    ///
+    /// If the map did not previously have this key present, then `None` is
+    /// returned.
+    ///
+    /// If the map did have this key present, the new value is associated with
+    /// the key and all previous values are removed. **Note** that only a single
+    /// one of the previous values is returned. If there are multiple values
+    /// that have been previously associated with the key, then the first one is
+    /// returned. See `insert_mult` on `OccupiedEntry` for an API that returns
+    /// all values.
+    ///
+    /// The key is not updated, though; this matters for types that can be `==`
+    /// without being identical.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// assert!(map.insert("x-host", "world".parse().unwrap()).is_none());
+    /// assert!(!map.is_empty());
+    ///
+    /// let mut prev = map.insert("x-host", "earth".parse().unwrap()).unwrap();
+    /// assert_eq!("world", prev);
+    /// ```
+    pub fn insert<K>(&mut self, key: K, val: MetadataValue) -> Option<MetadataValue>
+        where K: IntoMetadataKey
+    {
+        key.insert(self, val)
+    }
+
+    /// Inserts a key-value pair into the map.
+    ///
+    /// If the map did not previously have this key present, then `false` is
+    /// returned.
+    ///
+    /// If the map did have this key present, the new value is pushed to the end
+    /// of the list of values currently associated with the key. The key is not
+    /// updated, though; this matters for types that can be `==` without being
+    /// identical.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// assert!(map.insert("x-host", "world".parse().unwrap()).is_none());
+    /// assert!(!map.is_empty());
+    ///
+    /// map.append("x-host", "earth".parse().unwrap());
+    ///
+    /// let values = map.get_all("x-host");
+    /// let mut i = values.iter();
+    /// assert_eq!("world", *i.next().unwrap());
+    /// assert_eq!("earth", *i.next().unwrap());
+    /// ```
+    pub fn append<K>(&mut self, key: K, value: MetadataValue) -> bool
+        where K: IntoMetadataKey
+    {
+        key.append(self, value)
+    }
+
+    /// Removes a key from the map, returning the value associated with the key.
+    ///
+    /// Returns `None` if the map does not contain the key. If there are
+    /// multiple values associated with the key, then the first one is returned.
+    /// See `remove_entry_mult` on `OccupiedEntry` for an API that yields all
+    /// values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// map.insert("x-host", "hello.world".parse().unwrap());
+    ///
+    /// let prev = map.remove("x-host").unwrap();
+    /// assert_eq!("hello.world", prev);
+    ///
+    /// assert!(map.remove("x-host").is_none());
+    /// ```
+    pub fn remove<K>(&mut self, key: K) -> Option<MetadataValue>
+        where K: AsMetadataKey
+    {
+        key.remove(self)
+    }
+}
+
+// ===== impl Iter =====
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = (&'a str, &'a T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|item| {
+            let (ref name, ref value) = item;
+            let item : Self::Item = (&name.as_str(), &value);
+            item
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+unsafe impl<'a, T: Sync> Sync for Iter<'a, T> {}
+unsafe impl<'a, T: Sync> Send for Iter<'a, T> {}
+
+// ===== impl ValueDrain =====
+
+impl<'a, T> Iterator for ValueDrain<'a, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        self.inner.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+unsafe impl<'a, T: Sync> Sync for ValueDrain<'a, T> {}
+unsafe impl<'a, T: Send> Send for ValueDrain<'a, T> {}
+
+// ===== impl Drain =====
+
+impl<'a, T> Iterator for Drain<'a, T> {
+    type Item = (MetadataKey, ValueDrain<'a, T>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|item| {
+            let (name, drain) = item;
+            (MetadataKey { inner: name }, ValueDrain { inner: drain })
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+unsafe impl<'a, T: Sync> Sync for Drain<'a, T> {}
+unsafe impl<'a, T: Send> Send for Drain<'a, T> {}
+
+// ===== impl Keys =====
+
+impl<'a, T> Iterator for Keys<'a, T> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|b| b.as_str())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<'a, T> ExactSizeIterator for Keys<'a, T> {}
+
+// ===== impl Values ====
+
+impl<'a, T> Iterator for Values<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+// ===== impl ValueIter =====
+
+impl<'a, T: 'a> Iterator for ValueIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<'a, T: 'a> DoubleEndedIterator for ValueIter<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back()
+    }
+}
+
+// ===== impl ValueIterMut =====
+
+impl<'a, T: 'a> Iterator for ValueIterMut<'a, T> {
+    type Item = &'a mut T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+impl<'a, T: 'a> DoubleEndedIterator for ValueIterMut<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back()
+    }
+}
+
+unsafe impl<'a, T: Sync> Sync for ValueIterMut<'a, T> {}
+unsafe impl<'a, T: Send> Send for ValueIterMut<'a, T> {}
+
+// ===== impl Entry =====
+
+impl<'a, T> Entry<'a, T> {
+    /// Ensures a value is in the entry by inserting the default if empty.
+    ///
+    /// Returns a mutable reference to the **first** value in the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map: MetadataMap = MetadataMap::default();
+    ///
+    /// let keys = &[
+    ///     "content-length",
+    ///     "x-hello",
+    ///     "Content-Length",
+    ///     "x-world",
+    /// ];
+    ///
+    /// for &key in keys {
+    ///     let counter = map.entry(key)
+    ///         .expect("valid key names")
+    ///         .or_insert("".parse().unwrap());
+    ///     *counter = format!("{}{}", counter.to_str().unwrap(), "1").parse().unwrap();
+    /// }
+    ///
+    /// assert_eq!(map.get("content-length").unwrap(), "11");
+    /// assert_eq!(map.get("x-hello").unwrap(), "1");
+    /// ```
+    pub fn or_insert(self, default: T) -> &'a mut T {
+        use self::Entry::*;
+
+        match self {
+            Occupied(e) => e.into_mut(),
+            Vacant(e) => e.insert(default),
+        }
+    }
+
+    /// Ensures a value is in the entry by inserting the result of the default
+    /// function if empty.
+    ///
+    /// The default function is not called if the entry exists in the map.
+    /// Returns a mutable reference to the **first** value in the entry.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage.
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    ///
+    /// let res = map.entry("x-hello").unwrap()
+    ///     .or_insert_with(|| "world".parse().unwrap());
+    ///
+    /// assert_eq!(res, "world");
+    /// ```
+    ///
+    /// The default function is not called if the entry exists in the map.
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// map.insert("host", "world".parse().unwrap());
+    ///
+    /// let res = map.entry("host")
+    ///     .expect("host is a valid string")
+    ///     .or_insert_with(|| unreachable!());
+    ///
+    ///
+    /// assert_eq!(res, "world");
+    /// ```
+    pub fn or_insert_with<F: FnOnce() -> T>(self, default: F) -> &'a mut T {
+        use self::Entry::*;
+
+        match self {
+            Occupied(e) => e.into_mut(),
+            Vacant(e) => e.insert(default()),
+        }
+    }
+
+    /// Returns a reference to the entry's key
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    ///
+    /// assert_eq!(map.entry("x-hello").unwrap().key(), "x-hello");
+    /// ```
+    pub fn key(&self) -> &str {
+        use self::Entry::*;
+
+        match *self {
+            Vacant(ref e) => e.inner.key().as_str(),
+            Occupied(ref e) => e.inner.key().as_str(),
+        }
+    }
+}
+
+// ===== impl VacantEntry =====
+
+impl<'a, T> VacantEntry<'a, T> {
+    /// Returns a reference to the entry's key
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    ///
+    /// assert_eq!(map.entry("x-hello").unwrap().key(), "x-hello");
+    /// ```
+    pub fn key(&self) -> &str {
+        self.inner.key().as_str()
+    }
+
+    /// Take ownership of the key
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    ///
+    /// if let Entry::Vacant(v) = map.entry("x-hello").unwrap() {
+    ///     assert_eq!(v.into_key().as_str(), "x-hello");
+    /// }
+    /// ```
+    pub fn into_key(self) -> MetadataKey {
+        MetadataKey { inner: self.inner.into_key() }
+    }
+
+    /// Insert the value into the entry.
+    ///
+    /// The value will be associated with this entry's key. A mutable reference
+    /// to the inserted value will be returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    ///
+    /// if let Entry::Vacant(v) = map.entry("x-hello").unwrap() {
+    ///     v.insert("world".parse().unwrap());
+    /// }
+    ///
+    /// assert_eq!(map.get("x-hello").unwrap(), "world");
+    /// ```
+    pub fn insert(self, value: T) -> &'a mut T {
+        self.inner.insert(value)
+    }
+
+    /// Insert the value into the entry.
+    ///
+    /// The value will be associated with this entry's key. The new
+    /// `OccupiedEntry` is returned, allowing for further manipulation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    ///
+    /// if let Entry::Vacant(v) = map.entry("x-hello").unwrap() {
+    ///     let mut e = v.insert_entry("world".parse().unwrap());
+    ///     e.insert("world2".parse().unwrap());
+    /// }
+    ///
+    /// assert_eq!(map.get("x-hello").unwrap(), "world2");
+    /// ```
+    pub fn insert_entry(self, value: T) -> OccupiedEntry<'a, T> {
+        OccupiedEntry {
+            inner: self.inner.insert_entry(value)
+        }
+    }
+}
+
+// ===== impl OccupiedEntry =====
+
+impl<'a, T> OccupiedEntry<'a, T> {
+    /// Returns a reference to the entry's key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// map.insert("host", "world".parse().unwrap());
+    ///
+    /// if let Entry::Occupied(e) = map.entry("host").unwrap() {
+    ///     assert_eq!("host", e.key());
+    /// }
+    /// ```
+    pub fn key(&self) -> &str {
+        self.inner.key().as_str()
+    }
+
+    /// Get a reference to the first value in the entry.
+    ///
+    /// Values are stored in insertion order.
+    ///
+    /// # Panics
+    ///
+    /// `get` panics if there are no values associated with the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// map.insert("host", "hello.world".parse().unwrap());
+    ///
+    /// if let Entry::Occupied(mut e) = map.entry("host").unwrap() {
+    ///     assert_eq!(e.get(), &"hello.world");
+    ///
+    ///     e.append("hello.earth".parse().unwrap());
+    ///
+    ///     assert_eq!(e.get(), &"hello.world");
+    /// }
+    /// ```
+    pub fn get(&self) -> &T {
+        self.inner.get()
+    }
+
+    /// Get a mutable reference to the first value in the entry.
+    ///
+    /// Values are stored in insertion order.
+    ///
+    /// # Panics
+    ///
+    /// `get_mut` panics if there are no values associated with the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::default();
+    /// map.insert("host", "hello.world".parse().unwrap());
+    ///
+    /// if let Entry::Occupied(mut e) = map.entry("host").unwrap() {
+    ///     e.get_mut().set_sensitive(true);
+    ///     assert_eq!(e.get(), &"hello.world");
+    ///     assert!(e.get().is_sensitive());
+    /// }
+    /// ```
+    pub fn get_mut(&mut self) -> &mut T {
+        self.inner.get_mut()
+    }
+
+    /// Converts the `OccupiedEntry` into a mutable reference to the **first**
+    /// value.
+    ///
+    /// The lifetime of the returned reference is bound to the original map.
+    ///
+    /// # Panics
+    ///
+    /// `into_mut` panics if there are no values associated with the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::default();
+    /// map.insert("host", "hello.world".parse().unwrap());
+    /// map.append("host", "hello.earth".parse().unwrap());
+    ///
+    /// if let Entry::Occupied(e) = map.entry("host").unwrap() {
+    ///     e.into_mut().set_sensitive(true);
+    /// }
+    ///
+    /// assert!(map.get("host").unwrap().is_sensitive());
+    /// ```
+    pub fn into_mut(self) -> &'a mut T {
+        self.inner.into_mut()
+    }
+
+    /// Sets the value of the entry.
+    ///
+    /// All previous values associated with the entry are removed and the first
+    /// one is returned. See `insert_mult` for an API that returns all values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// map.insert("host", "hello.world".parse().unwrap());
+    ///
+    /// if let Entry::Occupied(mut e) = map.entry("host").unwrap() {
+    ///     let mut prev = e.insert("earth".parse().unwrap());
+    ///     assert_eq!("hello.world", prev);
+    /// }
+    ///
+    /// assert_eq!("earth", map.get("host").unwrap());
+    /// ```
+    pub fn insert(&mut self, value: T) -> T {
+        self.inner.insert(value)
+    }
+
+    /// Sets the value of the entry.
+    ///
+    /// This function does the same as `insert` except it returns an iterator
+    /// that yields all values previously associated with the key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// map.insert("host", "world".parse().unwrap());
+    /// map.append("host", "world2".parse().unwrap());
+    ///
+    /// if let Entry::Occupied(mut e) = map.entry("host").unwrap() {
+    ///     let mut prev = e.insert_mult("earth".parse().unwrap());
+    ///     assert_eq!("world", prev.next().unwrap());
+    ///     assert_eq!("world2", prev.next().unwrap());
+    ///     assert!(prev.next().is_none());
+    /// }
+    ///
+    /// assert_eq!("earth", map.get("host").unwrap());
+    /// ```
+    pub fn insert_mult(&mut self, value: T) -> ValueDrain<T> {
+        ValueDrain { inner: self.inner.insert_mult(value) }
+    }
+
+    /// Insert the value into the entry.
+    ///
+    /// The new value is appended to the end of the entry's value list. All
+    /// previous values associated with the entry are retained.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// map.insert("host", "world".parse().unwrap());
+    ///
+    /// if let Entry::Occupied(mut e) = map.entry("host").unwrap() {
+    ///     e.append("earth".parse().unwrap());
+    /// }
+    ///
+    /// let values = map.get_all("host");
+    /// let mut i = values.iter();
+    /// assert_eq!("world", *i.next().unwrap());
+    /// assert_eq!("earth", *i.next().unwrap());
+    /// ```
+    pub fn append(&mut self, value: T) {
+        self.inner.append(value)
+    }
+
+    /// Remove the entry from the map.
+    ///
+    /// All values associated with the entry are removed and the first one is
+    /// returned. See `remove_entry_mult` for an API that returns all values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// map.insert("host", "world".parse().unwrap());
+    ///
+    /// if let Entry::Occupied(e) = map.entry("host").unwrap() {
+    ///     let mut prev = e.remove();
+    ///     assert_eq!("world", prev);
+    /// }
+    ///
+    /// assert!(!map.contains_key("host"));
+    /// ```
+    pub fn remove(self) -> T {
+        self.inner.remove()
+    }
+
+    /// Remove the entry from the map.
+    ///
+    /// The key and all values associated with the entry are removed and the
+    /// first one is returned. See `remove_entry_mult` for an API that returns
+    /// all values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// map.insert("host", "world".parse().unwrap());
+    ///
+    /// if let Entry::Occupied(e) = map.entry("host").unwrap() {
+    ///     let (key, mut prev) = e.remove_entry();
+    ///     assert_eq!("host", key.as_str());
+    ///     assert_eq!("world", prev);
+    /// }
+    ///
+    /// assert!(!map.contains_key("host"));
+    /// ```
+    pub fn remove_entry(self) -> (MetadataKey, T) {
+        let (name, value) = self.inner.remove_entry();
+        (MetadataKey { inner: name }, value)
+    }
+
+    /// Remove the entry from the map.
+    ///
+    /// The key and all values associated with the entry are removed and
+    /// returned.
+    pub fn remove_entry_mult(self) -> (MetadataKey, ValueDrain<'a, T>) {
+        let (name, value_drain) = self.inner.remove_entry_mult();
+        (MetadataKey { inner: name }, ValueDrain { inner: value_drain })
+    }
+
+    /// Returns an iterator visiting all values associated with the entry.
+    ///
+    /// Values are iterated in insertion order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// map.insert("host", "world".parse().unwrap());
+    /// map.append("host", "earth".parse().unwrap());
+    ///
+    /// if let Entry::Occupied(e) = map.entry("host").unwrap() {
+    ///     let mut iter = e.iter();
+    ///     assert_eq!(&"world", iter.next().unwrap());
+    ///     assert_eq!(&"earth", iter.next().unwrap());
+    ///     assert!(iter.next().is_none());
+    /// }
+    /// ```
+    pub fn iter(&self) -> ValueIter<T> {
+        ValueIter { inner: self.inner.iter() }
+    }
+
+    /// Returns an iterator mutably visiting all values associated with the
+    /// entry.
+    ///
+    /// Values are iterated in insertion order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::default();
+    /// map.insert("host", "world".parse().unwrap());
+    /// map.append("host", "earth".parse().unwrap());
+    ///
+    /// if let Entry::Occupied(mut e) = map.entry("host").unwrap() {
+    ///     for e in e.iter_mut() {
+    ///         e.set_sensitive(true);
+    ///     }
+    /// }
+    ///
+    /// let mut values = map.get_all("host");
+    /// let mut i = values.iter();
+    /// assert!(i.next().unwrap().is_sensitive());
+    /// assert!(i.next().unwrap().is_sensitive());
+    /// ```
+    pub fn iter_mut(&mut self) -> ValueIterMut<T> {
+        ValueIterMut { inner: self.inner.iter_mut() }
+    }
+}
+
+impl<'a, T> IntoIterator for OccupiedEntry<'a, T> {
+    type Item = &'a mut T;
+    type IntoIter = ValueIterMut<'a, T>;
+
+    fn into_iter(self) -> ValueIterMut<'a, T> {
+        ValueIterMut { inner: self.inner.into_iter() }
+    }
+}
+
+impl<'a, 'b: 'a, T> IntoIterator for &'b OccupiedEntry<'a, T> {
+    type Item = &'a T;
+    type IntoIter = ValueIter<'a, T>;
+
+    fn into_iter(self) -> ValueIter<'a, T> {
+        self.iter()
+    }
+}
+
+impl<'a, 'b: 'a, T> IntoIterator for &'b mut OccupiedEntry<'a, T> {
+    type Item = &'a mut T;
+    type IntoIter = ValueIterMut<'a, T>;
+
+    fn into_iter(self) -> ValueIterMut<'a, T> {
+        self.iter_mut()
+    }
+}
+
+// ===== impl GetAll =====
+
+impl<'a> GetAll<'a> {
+    /// Returns an iterator visiting all values associated with the entry.
+    ///
+    /// Values are iterated in insertion order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut map = MetadataMap::new();
+    /// map.insert("x-host", "hello.world".parse().unwrap());
+    /// map.append("x-host", "hello.earth".parse().unwrap());
+    ///
+    /// let values = map.get_all("x-host");
+    /// let mut iter = values.iter();
+    /// assert_eq!(&"hello.world", iter.next().unwrap());
+    /// assert_eq!(&"hello.earth", iter.next().unwrap());
+    /// assert!(iter.next().is_none());
+    /// ```
+    pub fn iter(&self) -> ValueIter<'a, MetadataValue> {
+        ValueIter { inner: self.inner.iter() }
+    }
+}
+
+impl<'a> PartialEq for GetAll<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.iter().eq(other.inner.iter())
+    }
+}
+
+impl<'a> IntoIterator for GetAll<'a> {
+    type Item = &'a MetadataValue;
+    type IntoIter = ValueIter<'a, MetadataValue>;
+
+    fn into_iter(self) -> ValueIter<'a, MetadataValue> {
+        ValueIter { inner: self.inner.into_iter() }
+    }
+}
+
+impl<'a, 'b: 'a> IntoIterator for &'b GetAll<'a> {
+    type Item = &'a MetadataValue;
+    type IntoIter = ValueIter<'a, MetadataValue>;
+
+    fn into_iter(self) -> ValueIter<'a, MetadataValue> {
+        ValueIter {
+            inner: (&self.inner).into_iter()
+        }
+    }
+}
+
+// ===== impl IntoMetadataKey / AsMetadataKey =====
+
+mod into_metadata_key {
+    use super::{MetadataMap, MetadataValue};
+    use metadata_key::MetadataKey;
+
+    /// A marker trait used to identify values that can be used as insert keys
+    /// to a `MetadataMap`.
+    pub trait IntoMetadataKey: Sealed {}
+
+    // All methods are on this pub(super) trait, instead of `IntoMetadataKey`,
+    // so that they aren't publicly exposed to the world.
+    //
+    // Being on the `IntoMetadataKey` trait would mean users could call
+    // `"host".insert(&mut map, "localhost")`.
+    //
+    // Ultimately, this allows us to adjust the signatures of these methods
+    // without breaking any external crate.
+    pub trait Sealed {
+        #[doc(hidden)]
+        fn insert(self, map: &mut MetadataMap, val: MetadataValue) -> Option<MetadataValue>;
+
+        #[doc(hidden)]
+        fn append(self, map: &mut MetadataMap, val: MetadataValue) -> bool;
+    }
+
+    // ==== impls ====
+
+    impl Sealed for MetadataKey {
+        #[doc(hidden)]
+        #[inline]
+        fn insert(self, map: &mut MetadataMap, val: MetadataValue) -> Option<MetadataValue> {
+            map.headers.insert(self.inner, val)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn append(self, map: &mut MetadataMap, val: MetadataValue) -> bool {
+            map.headers.append(self.inner, val)
+        }
+    }
+
+    impl IntoMetadataKey for MetadataKey {}
+
+    impl<'a> Sealed for &'a MetadataKey {
+        #[doc(hidden)]
+        #[inline]
+        fn insert(self, map: &mut MetadataMap, val: MetadataValue) -> Option<MetadataValue> {
+            map.headers.insert(&self.inner, val)
+        }
+        #[doc(hidden)]
+        #[inline]
+        fn append(self, map: &mut MetadataMap, val: MetadataValue) -> bool {
+            map.headers.append(&self.inner, val)
+        }
+    }
+
+    impl<'a> IntoMetadataKey for &'a MetadataKey {}
+
+    impl Sealed for &'static str {
+        #[doc(hidden)]
+        #[inline]
+        fn insert(self, map: &mut MetadataMap, val: MetadataValue) -> Option<MetadataValue> {
+            map.headers.insert(self, val)
+        }
+        #[doc(hidden)]
+        #[inline]
+        fn append(self, map: &mut MetadataMap, val: MetadataValue) -> bool {
+            map.headers.append(self, val)
+        }
+    }
+
+    impl IntoMetadataKey for &'static str {}
+}
+
+mod as_metadata_key {
+    use super::{MetadataMap, MetadataValue};
+    use metadata_key::MetadataKey;
+    use http::header::{Entry, GetAll, InvalidHeaderName};
+
+    /// A marker trait used to identify values that can be used as search keys
+    /// to a `MetadataMap`.
+    pub trait AsMetadataKey: Sealed {}
+
+    // All methods are on this pub(super) trait, instead of `AsMetadataKey`,
+    // so that they aren't publicly exposed to the world.
+    //
+    // Being on the `AsMetadataKey` trait would mean users could call
+    // `"host".find(&map)`.
+    //
+    // Ultimately, this allows us to adjust the signatures of these methods
+    // without breaking any external crate.
+    pub trait Sealed {
+        #[doc(hidden)]
+        fn get(self, map: &MetadataMap) -> Option<&MetadataValue>;
+
+        #[doc(hidden)]
+        fn get_mut(self, map: &mut MetadataMap) -> Option<&mut MetadataValue>;
+
+        #[doc(hidden)]
+        fn get_all(self, map: &MetadataMap) -> GetAll<MetadataValue>;
+
+        #[doc(hidden)]
+        fn contains_key(&self, map: &MetadataMap) -> bool;
+
+        #[doc(hidden)]
+        fn entry(self, map: &mut MetadataMap) -> Result<Entry<MetadataValue>, InvalidHeaderName>;
+
+        #[doc(hidden)]
+        fn remove(self, map: &mut MetadataMap) -> Option<MetadataValue>;
+    }
+
+    // ==== impls ====
+
+    impl Sealed for MetadataKey {
+        #[doc(hidden)]
+        #[inline]
+        fn get(self, map: &MetadataMap) -> Option<&MetadataValue> {
+            map.headers.get(self.inner)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn get_mut(self, map: &mut MetadataMap) -> Option<&mut MetadataValue> {
+            map.headers.get_mut(self.inner)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn get_all(self, map: &MetadataMap) -> GetAll<MetadataValue> {
+            map.headers.get_all(self.inner)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn contains_key(&self, map: &MetadataMap) -> bool {
+            map.headers.contains_key(&self.inner)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn entry(self, map: &mut MetadataMap) -> Result<Entry<MetadataValue>, InvalidHeaderName> {
+            map.headers.entry(self.inner)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn remove(self, map: &mut MetadataMap) -> Option<MetadataValue> {
+            map.headers.remove(self.inner)
+        }
+    }
+
+    impl AsMetadataKey for MetadataKey {}
+
+    impl<'a> Sealed for &'a MetadataKey {
+        #[doc(hidden)]
+        #[inline]
+        fn get(self, map: &MetadataMap) -> Option<&MetadataValue> {
+            map.headers.get(&self.inner)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn get_mut(self, map: &mut MetadataMap) -> Option<&mut MetadataValue> {
+            map.headers.get_mut(&self.inner)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn get_all(self, map: &MetadataMap) -> GetAll<MetadataValue> {
+            map.headers.get_all(&self.inner)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn contains_key(&self, map: &MetadataMap) -> bool {
+            map.headers.contains_key(&self.inner)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn entry(self, map: &mut MetadataMap) -> Result<Entry<MetadataValue>, InvalidHeaderName> {
+            map.headers.entry(&self.inner)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn remove(self, map: &mut MetadataMap) -> Option<MetadataValue> {
+            map.headers.remove(&self.inner)
+        }
+    }
+
+    impl<'a> AsMetadataKey for &'a MetadataKey {}
+
+    impl<'a> Sealed for &'a str {
+        #[doc(hidden)]
+        #[inline]
+        fn get(self, map: &MetadataMap) -> Option<&MetadataValue> {
+            map.headers.get(self)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn get_mut(self, map: &mut MetadataMap) -> Option<&mut MetadataValue> {
+            map.headers.get_mut(self)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn get_all(self, map: &MetadataMap) -> GetAll<MetadataValue> {
+            map.headers.get_all(self)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn contains_key(&self, map: &MetadataMap) -> bool {
+            map.headers.contains_key(*self)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn entry(self, map: &mut MetadataMap) -> Result<Entry<MetadataValue>, InvalidHeaderName> {
+            map.headers.entry(self)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn remove(self, map: &mut MetadataMap) -> Option<MetadataValue> {
+            map.headers.remove(self)
+        }
+    }
+
+    impl<'a> AsMetadataKey for &'a str {}
+
+    impl Sealed for String {
+        #[doc(hidden)]
+        #[inline]
+        fn get(self, map: &MetadataMap) -> Option<&MetadataValue> {
+            map.headers.get(self.as_str())
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn get_mut(self, map: &mut MetadataMap) -> Option<&mut MetadataValue> {
+            map.headers.get_mut(self.as_str())
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn get_all(self, map: &MetadataMap) -> GetAll<MetadataValue> {
+            map.headers.get_all(self.as_str())
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn contains_key(&self, map: &MetadataMap) -> bool {
+            map.headers.contains_key(self.as_str())
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn entry(self, map: &mut MetadataMap) -> Result<Entry<MetadataValue>, InvalidHeaderName> {
+            map.headers.entry(self.as_str())
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn remove(self, map: &mut MetadataMap) -> Option<MetadataValue> {
+            map.headers.remove(self.as_str())
+        }
+    }
+
+    impl AsMetadataKey for String {}
+
+    impl<'a> Sealed for &'a String {
+        #[doc(hidden)]
+        #[inline]
+        fn get(self, map: &MetadataMap) -> Option<&MetadataValue> {
+            map.headers.get(self.as_str())
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn get_mut(self, map: &mut MetadataMap) -> Option<&mut MetadataValue> {
+            map.headers.get_mut(self.as_str())
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn get_all(self, map: &MetadataMap) -> GetAll<MetadataValue> {
+            map.headers.get_all(self.as_str())
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn contains_key(&self, map: &MetadataMap) -> bool {
+            map.headers.contains_key(self.as_str())
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn entry(self, map: &mut MetadataMap) -> Result<Entry<MetadataValue>, InvalidHeaderName> {
+            map.headers.entry(self.as_str())
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn remove(self, map: &mut MetadataMap) -> Option<MetadataValue> {
+            map.headers.remove(self.as_str())
+        }
+    }
+
+    impl<'a> AsMetadataKey for &'a String {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_headers_takes_http_headers() {
+        let mut http_map = http::HeaderMap::new();
+        http_map.insert("x-host", "example.com".parse().unwrap());
+
+        let map = MetadataMap::from_headers(http_map);
+
+        assert_eq!(map.get("x-host").unwrap(), "example.com");
+    }
+}

--- a/src/metadata_map.rs
+++ b/src/metadata_map.rs
@@ -442,6 +442,10 @@ impl MetadataMap {
     }
 
     /*
+    TODO(pgron): Add this once
+    https://github.com/hyperium/http/commit/22ec10aaa331c5e2414b7ea8ecfd4b4d0d19b6ee
+    has been released.
+
     /// An iterator visiting all key-value pairs, with mutable value references.
     ///
     /// The iterator order is arbitrary, but consistent across platforms for the
@@ -462,7 +466,6 @@ impl MetadataMap {
     ///     value.set_sensitive(true);
     /// }
     /// ```
-    // TODO(pgron): Expose this. Blocked by https://github.com/hyperium/http/pull/278
     pub fn iter_mut(&mut self) -> http::header::map::IterMut<MetadataValue> {
         self.headers.iter_mut()
     }*/
@@ -514,7 +517,11 @@ impl MetadataMap {
         Values { inner: self.headers.values() }
     }
 
-/*
+    /*
+    TODO(pgron): Add this once
+    https://github.com/hyperium/http/commit/22ec10aaa331c5e2414b7ea8ecfd4b4d0d19b6ee
+    has been released.
+
     /// An iterator visiting all values mutably.
     ///
     /// The iteration order is arbitrary, but consistent across platforms for
@@ -537,7 +544,8 @@ impl MetadataMap {
     // TODO(pgron): Expose this. Blocked by https://github.com/hyperium/http/pull/278
     pub fn values_mut(&mut self) -> http::header::ValuesMut<MetadataValue> {
         self.headers.values_mut()
-    }*/
+    }
+    */
 
     /// Clears the map, returning all entries as an iterator.
     ///

--- a/src/metadata_map.rs
+++ b/src/metadata_map.rs
@@ -216,7 +216,7 @@ impl MetadataMap {
     ///
     /// assert_eq!(2, map.len());
     ///
-    /// map.append("x-mime-type", "text/html".parse().unwrap());
+    /// map.append("x-host-ip", "text/html".parse().unwrap());
     ///
     /// assert_eq!(3, map.len());
     /// ```
@@ -237,17 +237,17 @@ impl MetadataMap {
     ///
     /// assert_eq!(0, map.keys_len());
     ///
-    /// map.insert("x-mime", "text/plain".parse().unwrap());
-    /// map.insert("x-host", "localhost".parse().unwrap());
+    /// map.insert("x-host-ip", "127.0.0.1".parse().unwrap());
+    /// map.insert("x-host-name", "localhost".parse().unwrap());
     ///
     /// assert_eq!(2, map.keys_len());
     ///
-    /// map.insert("x-mime", "text/html".parse().unwrap());
+    /// map.append("x-host-ip", "text/html".parse().unwrap());
     ///
     /// assert_eq!(2, map.keys_len());
     /// ```
     pub fn keys_len(&self) -> usize {
-        self.headers.len()
+        self.headers.keys_len()
     }
 
     /// Returns true if the map contains no elements.
@@ -355,7 +355,6 @@ impl MetadataMap {
     pub fn get<K>(&self, key: K) -> Option<&MetadataValue>
         where K: AsMetadataKey
     {
-
         key.get(self)
     }
 

--- a/src/metadata_map.rs
+++ b/src/metadata_map.rs
@@ -934,13 +934,13 @@ impl<'a> Entry<'a> {
     ///
     /// assert_eq!(map.entry("x-hello").unwrap().key(), "x-hello");
     /// ```
-    pub fn key(&self) -> &str {
+    pub fn key(&self) -> &MetadataKey {
         use self::Entry::*;
 
-        match *self {
-            Vacant(ref e) => e.inner.key().as_str(),
-            Occupied(ref e) => e.inner.key().as_str(),
-        }
+        MetadataKey::from_header_name(match *self {
+            Vacant(ref e) => e.inner.key(),
+            Occupied(ref e) => e.inner.key(),
+        })
     }
 }
 
@@ -957,8 +957,8 @@ impl<'a> VacantEntry<'a> {
     ///
     /// assert_eq!(map.entry("x-hello").unwrap().key(), "x-hello");
     /// ```
-    pub fn key(&self) -> &str {
-        self.inner.key().as_str()
+    pub fn key(&self) -> &MetadataKey {
+        MetadataKey::from_header_name(self.inner.key())
     }
 
     /// Take ownership of the key
@@ -1039,8 +1039,8 @@ impl<'a> OccupiedEntry<'a> {
     ///     assert_eq!("host", e.key());
     /// }
     /// ```
-    pub fn key(&self) -> &str {
-        self.inner.key().as_str()
+    pub fn key(&self) -> &MetadataKey {
+        MetadataKey::from_header_name(self.inner.key())
     }
 
     /// Get a reference to the first value in the entry.

--- a/src/metadata_value.rs
+++ b/src/metadata_value.rs
@@ -1,0 +1,616 @@
+use bytes::Bytes;
+use http::header::HeaderValue;
+
+use std::{cmp, fmt};
+use std::error::Error;
+use std::str::FromStr;
+
+use metadata_key::MetadataKey;
+
+/// Represents a custom metadata field value.
+///
+/// `MetadataValue` is used as the [`MetadataMap`] value.
+///
+/// [`HeaderMap`]: struct.HeaderMap.html
+#[derive(Clone, Hash)]
+pub struct MetadataValue {
+    pub(crate) inner: HeaderValue,
+}
+
+/// A possible error when converting a `MetadataValue` from a string or byte
+/// slice.
+#[derive(Debug)]
+pub struct InvalidMetadataValue {
+    _priv: (),
+}
+
+/// A possible error when converting a `MetadataValue` from a string or byte
+/// slice.
+#[derive(Debug)]
+pub struct InvalidMetadataValueBytes(InvalidMetadataValue);
+
+/// A possible error when converting a `MetadataValue` to a string representation.
+///
+/// Metadata field values may contain opaque bytes, in which case it is not
+/// possible to represent the value as a string.
+#[derive(Debug)]
+pub struct ToStrError {
+    _priv: (),
+}
+
+impl MetadataValue {
+    /// Convert a static string to a `MetadataValue`.
+    ///
+    /// This function will not perform any copying, however the string is
+    /// checked to ensure that no invalid characters are present. Only visible
+    /// ASCII characters (32-127) are permitted.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the argument contains invalid metadata value
+    /// characters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let val = MetadataValue::from_static("hello");
+    /// assert_eq!(val, "hello");
+    /// ```
+    #[inline]
+    pub fn from_static(src: &'static str) -> MetadataValue {
+        MetadataValue {
+            inner: HeaderValue::from_static(src)
+        }
+    }
+
+    /// Attempt to convert a string to a `MetadataValue`.
+    ///
+    /// If the argument contains invalid metadata value characters, an error is
+    /// returned. Only visible ASCII characters (32-127) are permitted. Use
+    /// `from_bytes` to create a `MetadataValue` that includes opaque octets
+    /// (128-255).
+    ///
+    /// This function is intended to be replaced in the future by a `TryFrom`
+    /// implementation once the trait is stabilized in std.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let val = MetadataValue::from_str("hello").unwrap();
+    /// assert_eq!(val, "hello");
+    /// ```
+    ///
+    /// An invalid value
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let val = MetadataValue::from_str("\n");
+    /// assert!(val.is_err());
+    /// ```
+    #[inline]
+    pub fn from_str(src: &str) -> Result<MetadataValue, InvalidMetadataValue> {
+        HeaderValue::from_str(src)
+            .map(|value| MetadataValue {
+                inner: value
+            })
+            .map_err(|_| { InvalidMetadataValue { _priv: () } })
+    }
+
+    /// Converts a MetadataKey into a MetadataValue
+    ///
+    /// Since every valid MetadataKey is a valid MetadataValue this is done
+    /// infallibly.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let val = MetadataValue::from_name("accept".parse().unwrap());
+    /// assert_eq!(val, MetadataValue::from_bytes(b"accept").unwrap());
+    /// ```
+    #[inline]
+    pub fn from_name(name: MetadataKey) -> MetadataValue {
+        name.into()
+    }
+
+    /// Attempt to convert a byte slice to a `MetadataValue`.
+    ///
+    /// If the argument contains invalid metadata value bytes, an error is
+    /// returned. Only byte values between 32 and 255 (inclusive) are permitted,
+    /// excluding byte 127 (DEL).
+    ///
+    /// This function is intended to be replaced in the future by a `TryFrom`
+    /// implementation once the trait is stabilized in std.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let val = MetadataValue::from_bytes(b"hello\xfa").unwrap();
+    /// assert_eq!(val, &b"hello\xfa"[..]);
+    /// ```
+    ///
+    /// An invalid value
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let val = MetadataValue::from_bytes(b"\n");
+    /// assert!(val.is_err());
+    /// ```
+    #[inline]
+    pub fn from_bytes(src: &[u8]) -> Result<MetadataValue, InvalidMetadataValue> {
+        HeaderValue::from_bytes(src)
+            .map(|value| MetadataValue {
+                inner: value
+            })
+            .map_err(|_| { InvalidMetadataValue { _priv: () } })
+    }
+
+    /// Attempt to convert a `Bytes` buffer to a `MetadataValue`.
+    ///
+    /// If the argument contains invalid metadata value bytes, an error is
+    /// returned. Only byte values between 32 and 255 (inclusive) are permitted,
+    /// excluding byte 127 (DEL).
+    ///
+    /// This function is intended to be replaced in the future by a `TryFrom`
+    /// implementation once the trait is stabilized in std.
+    #[inline]
+    pub fn from_shared(src: Bytes) -> Result<MetadataValue, InvalidMetadataValueBytes> {
+        HeaderValue::from_shared(src)
+            .map(|value| MetadataValue {
+                inner: value
+            })
+            .map_err(|_| {
+                InvalidMetadataValueBytes(InvalidMetadataValue { _priv: () })
+            })
+    }
+
+    /// Convert a `Bytes` directly into a `MetadataValue` without validating.
+    ///
+    /// This function does NOT validate that illegal bytes are not contained
+    /// within the buffer.
+    #[inline]
+    pub unsafe fn from_shared_unchecked(src: Bytes) -> MetadataValue {
+        MetadataValue {
+            inner: HeaderValue::from_shared_unchecked(src)
+        }
+    }
+
+    /// Yields a `&str` slice if the `MetadataValue` only contains visible ASCII
+    /// chars.
+    ///
+    /// This function will perform a scan of the metadata value, checking all the
+    /// characters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let val = MetadataValue::from_static("hello");
+    /// assert_eq!(val.to_str().unwrap(), "hello");
+    /// ```
+    pub fn to_str(&self) -> Result<&str, ToStrError> {
+        return self.inner.to_str().map_err(|_| { ToStrError { _priv: () } })
+    }
+
+    /// Returns the length of `self`.
+    ///
+    /// This length is in bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let val = MetadataValue::from_static("hello");
+    /// assert_eq!(val.len(), 5);
+    /// ```
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns true if the `MetadataValue` has a length of zero bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let val = MetadataValue::from_static("");
+    /// assert!(val.is_empty());
+    ///
+    /// let val = MetadataValue::from_static("hello");
+    /// assert!(!val.is_empty());
+    /// ```
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Converts a `MetadataValue` to a byte slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let val = MetadataValue::from_static("hello");
+    /// assert_eq!(val.as_bytes(), b"hello");
+    /// ```
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+
+    /// Mark that the metadata value represents sensitive information.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut val = MetadataValue::from_static("my secret");
+    ///
+    /// val.set_sensitive(true);
+    /// assert!(val.is_sensitive());
+    ///
+    /// val.set_sensitive(false);
+    /// assert!(!val.is_sensitive());
+    /// ```
+    #[inline]
+    pub fn set_sensitive(&mut self, val: bool) {
+        self.inner.set_sensitive(val);
+    }
+
+    /// Returns `true` if the value represents sensitive data.
+    ///
+    /// Sensitive data could represent passwords or other data that should not
+    /// be stored on disk or in memory. This setting can be used by components
+    /// like caches to avoid storing the value. HPACK encoders must set the
+    /// metadata field to never index when `is_sensitive` returns true.
+    ///
+    /// Note that sensitivity is not factored into equality or ordering.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let mut val = MetadataValue::from_static("my secret");
+    ///
+    /// val.set_sensitive(true);
+    /// assert!(val.is_sensitive());
+    ///
+    /// val.set_sensitive(false);
+    /// assert!(!val.is_sensitive());
+    /// ```
+    #[inline]
+    pub fn is_sensitive(&self) -> bool {
+        self.inner.is_sensitive()
+    }
+}
+
+impl AsRef<[u8]> for MetadataValue {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.inner.as_ref()
+    }
+}
+
+impl fmt::Debug for MetadataValue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl From<MetadataKey> for MetadataValue {
+    #[inline]
+    fn from(h: MetadataKey) -> MetadataValue {
+        MetadataValue {
+            inner: h.inner.into()
+        }
+    }
+}
+
+macro_rules! from_integers {
+    ($($name:ident: $t:ident => $max_len:expr),*) => {$(
+        impl From<$t> for MetadataValue {
+            fn from(num: $t) -> MetadataValue {
+                MetadataValue {
+                    inner: HeaderValue::from(num)
+                }
+            }
+        }
+
+        #[test]
+        fn $name() {
+            let n: $t = 55;
+            let val = MetadataValue::from(n);
+            assert_eq!(val, &n.to_string());
+
+            let n = ::std::$t::MAX;
+            let val = MetadataValue::from(n);
+            assert_eq!(val, &n.to_string());
+        }
+    )*};
+}
+
+from_integers! {
+    // integer type => maximum decimal length
+
+    // u8 purposely left off... MetadataValue::from(b'3') could be confusing
+    from_u16: u16 => 5,
+    from_i16: i16 => 6,
+    from_u32: u32 => 10,
+    from_i32: i32 => 11,
+    from_u64: u64 => 20,
+    from_i64: i64 => 20
+}
+
+#[cfg(target_pointer_width = "16")]
+from_integers! {
+    from_usize: usize => 5,
+    from_isize: isize => 6
+}
+
+#[cfg(target_pointer_width = "32")]
+from_integers! {
+    from_usize: usize => 10,
+    from_isize: isize => 11
+}
+
+#[cfg(target_pointer_width = "64")]
+from_integers! {
+    from_usize: usize => 20,
+    from_isize: isize => 20
+}
+
+#[cfg(test)]
+mod from_metadata_name_tests {
+    //use super::*;
+    use metadata_map::MetadataMap;
+
+    #[test]
+    fn it_can_insert_metadata_key_as_metadata_value() {
+        let mut _map = MetadataMap::new();
+/* TODO(pgron): Add me back
+        map.insert("accept", MetadataKey::from_bytes(b"hello-world").unwrap().into());
+
+        assert_eq!(
+            map.get("accept").unwrap(),
+            MetadataValue::from_bytes(b"hello-world").unwrap()
+        );
+        */
+    }
+}
+
+impl FromStr for MetadataValue {
+    type Err = InvalidMetadataValue;
+
+    #[inline]
+    fn from_str(s: &str) -> Result<MetadataValue, Self::Err> {
+        MetadataValue::from_str(s)
+    }
+}
+
+impl From<MetadataValue> for Bytes {
+    #[inline]
+    fn from(value: MetadataValue) -> Bytes {
+        Bytes::from(value.inner)
+    }
+}
+
+impl<'a> From<&'a MetadataValue> for MetadataValue {
+    #[inline]
+    fn from(t: &'a MetadataValue) -> Self {
+        t.clone()
+    }
+}
+
+impl fmt::Display for InvalidMetadataValue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.description().fmt(f)
+    }
+}
+
+impl Error for InvalidMetadataValue {
+    fn description(&self) -> &str {
+        "failed to parse metadata value"
+    }
+}
+
+impl fmt::Display for InvalidMetadataValueBytes {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Error for InvalidMetadataValueBytes {
+    fn description(&self) -> &str {
+        self.0.description()
+    }
+}
+
+impl fmt::Display for ToStrError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.description().fmt(f)
+    }
+}
+
+impl Error for ToStrError {
+    fn description(&self) -> &str {
+        "failed to convert metadata to a str"
+    }
+}
+
+// ===== PartialEq / PartialOrd =====
+
+impl PartialEq for MetadataValue {
+    #[inline]
+    fn eq(&self, other: &MetadataValue) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl Eq for MetadataValue {}
+
+impl PartialOrd for MetadataValue {
+    #[inline]
+    fn partial_cmp(&self, other: &MetadataValue) -> Option<cmp::Ordering> {
+        self.inner.partial_cmp(&other.inner)
+    }
+}
+
+impl Ord for MetadataValue {
+    #[inline]
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.inner.cmp(&other.inner)
+    }
+}
+
+impl PartialEq<str> for MetadataValue {
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        self.inner == other.as_bytes()
+    }
+}
+
+impl PartialEq<[u8]> for MetadataValue {
+    #[inline]
+    fn eq(&self, other: &[u8]) -> bool {
+        self.inner == other
+    }
+}
+
+impl PartialOrd<str> for MetadataValue {
+    #[inline]
+    fn partial_cmp(&self, other: &str) -> Option<cmp::Ordering> {
+        self.inner.partial_cmp(other.as_bytes())
+    }
+}
+
+impl PartialOrd<[u8]> for MetadataValue {
+    #[inline]
+    fn partial_cmp(&self, other: &[u8]) -> Option<cmp::Ordering> {
+        self.inner.partial_cmp(other)
+    }
+}
+
+impl PartialEq<MetadataValue> for str {
+    #[inline]
+    fn eq(&self, other: &MetadataValue) -> bool {
+        *other == *self
+    }
+}
+
+impl PartialEq<MetadataValue> for [u8] {
+    #[inline]
+    fn eq(&self, other: &MetadataValue) -> bool {
+        *other == *self
+    }
+}
+
+impl PartialOrd<MetadataValue> for str {
+    #[inline]
+    fn partial_cmp(&self, other: &MetadataValue) -> Option<cmp::Ordering> {
+        self.as_bytes().partial_cmp(other.as_bytes())
+    }
+}
+
+impl PartialOrd<MetadataValue> for [u8] {
+    #[inline]
+    fn partial_cmp(&self, other: &MetadataValue) -> Option<cmp::Ordering> {
+        self.partial_cmp(other.as_bytes())
+    }
+}
+
+impl PartialEq<String> for MetadataValue {
+    #[inline]
+    fn eq(&self, other: &String) -> bool {
+        *self == &other[..]
+    }
+}
+
+impl PartialOrd<String> for MetadataValue {
+    #[inline]
+    fn partial_cmp(&self, other: &String) -> Option<cmp::Ordering> {
+        self.inner.partial_cmp(other.as_bytes())
+    }
+}
+
+impl PartialEq<MetadataValue> for String {
+    #[inline]
+    fn eq(&self, other: &MetadataValue) -> bool {
+        *other == *self
+    }
+}
+
+impl PartialOrd<MetadataValue> for String {
+    #[inline]
+    fn partial_cmp(&self, other: &MetadataValue) -> Option<cmp::Ordering> {
+        self.as_bytes().partial_cmp(other.as_bytes())
+    }
+}
+
+impl<'a> PartialEq<MetadataValue> for &'a MetadataValue {
+    #[inline]
+    fn eq(&self, other: &MetadataValue) -> bool {
+        **self == *other
+    }
+}
+
+impl<'a> PartialOrd<MetadataValue> for &'a MetadataValue {
+    #[inline]
+    fn partial_cmp(&self, other: &MetadataValue) -> Option<cmp::Ordering> {
+        (**self).partial_cmp(other)
+    }
+}
+
+impl<'a, T: ?Sized> PartialEq<&'a T> for MetadataValue
+    where MetadataValue: PartialEq<T>
+{
+    #[inline]
+    fn eq(&self, other: &&'a T) -> bool {
+        *self == **other
+    }
+}
+
+impl<'a, T: ?Sized> PartialOrd<&'a T> for MetadataValue
+    where MetadataValue: PartialOrd<T>
+{
+    #[inline]
+    fn partial_cmp(&self, other: &&'a T) -> Option<cmp::Ordering> {
+        self.partial_cmp(*other)
+    }
+}
+
+impl<'a> PartialEq<MetadataValue> for &'a str {
+    #[inline]
+    fn eq(&self, other: &MetadataValue) -> bool {
+        *other == *self
+    }
+}
+
+impl<'a> PartialOrd<MetadataValue> for &'a str {
+    #[inline]
+    fn partial_cmp(&self, other: &MetadataValue) -> Option<cmp::Ordering> {
+        self.as_bytes().partial_cmp(other.as_bytes())
+    }
+}
+
+#[test]
+fn test_debug() {
+    let cases = &[
+        ("hello", "\"hello\""),
+        ("hello \"world\"", "\"hello \\\"world\\\"\""),
+        ("\u{7FFF}hello", "\"\\xe7\\xbf\\xbfhello\""),
+    ];
+
+    for &(value, expected) in cases {
+        let val = MetadataValue::from_bytes(value.as_bytes()).unwrap();
+        let actual = format!("{:?}", val);
+        assert_eq!(expected, actual);
+    }
+
+    let mut sensitive = MetadataValue::from_static("password");
+    sensitive.set_sensitive(true);
+    assert_eq!("Sensitive", format!("{:?}", sensitive));
+}

--- a/src/metadata_value.rs
+++ b/src/metadata_value.rs
@@ -13,6 +13,7 @@ use metadata_key::MetadataKey;
 ///
 /// [`HeaderMap`]: struct.HeaderMap.html
 #[derive(Clone, Hash)]
+#[repr(transparent)]
 pub struct MetadataValue {
     // Note: There are unsafe transmutes that assume that the memory layout
     // of MetadataValue is identical to HeaderValue

--- a/src/metadata_value.rs
+++ b/src/metadata_value.rs
@@ -14,6 +14,8 @@ use metadata_key::MetadataKey;
 /// [`HeaderMap`]: struct.HeaderMap.html
 #[derive(Clone, Hash)]
 pub struct MetadataValue {
+    // Note: There are unsafe transmutes that assume that the memory layout
+    // of MetadataValue is identical to HeaderValue
     pub(crate) inner: HeaderValue,
 }
 
@@ -285,6 +287,16 @@ impl MetadataValue {
     #[inline]
     pub fn is_sensitive(&self) -> bool {
         self.inner.is_sensitive()
+    }
+
+    #[inline]
+    pub(crate) fn from_header_value(header_value: &HeaderValue) -> &Self {
+        unsafe { &*(header_value as *const HeaderValue as *const Self) }
+    }
+
+    #[inline]
+    pub(crate) fn from_mut_header_value(header_value: &mut HeaderValue) -> &mut Self {
+        unsafe { &mut *(header_value as *mut HeaderValue as *mut Self) }
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,7 +2,7 @@ use http;
 
 #[derive(Debug)]
 pub struct Request<T> {
-    headers: http::HeaderMap,
+    metadata: http::HeaderMap,
     message: T,
 }
 
@@ -10,7 +10,7 @@ impl<T> Request<T> {
     /// Create a new gRPC request
     pub fn new(message: T) -> Self {
         Request {
-            headers: http::HeaderMap::new(),
+            metadata: http::HeaderMap::new(),
             message,
         }
     }
@@ -25,14 +25,14 @@ impl<T> Request<T> {
         &mut self.message
     }
 
-    /// Get a reference to the request headers.
-    pub fn headers(&self) -> &http::HeaderMap {
-        &self.headers
+    /// Get a reference to the custom request metadata.
+    pub fn metadata(&self) -> &http::HeaderMap {
+        &self.metadata
     }
 
-    /// Get a mutable reference to the request headers.
-    pub fn headers_mut(&mut self) -> &mut http::HeaderMap {
-        &mut self.headers
+    /// Get a mutable reference to the request metadata.
+    pub fn metadata_mut(&mut self) -> &mut http::HeaderMap {
+        &mut self.metadata
     }
 
     /// Consumes `self`, returning the message
@@ -44,7 +44,7 @@ impl<T> Request<T> {
     pub fn from_http(http: http::Request<T>) -> Self {
         let (head, message) = http.into_parts();
         Request {
-            headers: head.headers,
+            metadata: head.headers,
             message,
         }
     }
@@ -55,7 +55,7 @@ impl<T> Request<T> {
         *request.version_mut() = http::Version::HTTP_2;
         *request.method_mut() = http::Method::POST;
         *request.uri_mut() = uri;
-        *request.headers_mut() = self.headers;
+        *request.headers_mut() = self.metadata;
 
         request
     }
@@ -66,7 +66,7 @@ impl<T> Request<T> {
         let message = f(self.message);
 
         Request {
-            headers: self.headers,
+            metadata: self.metadata,
             message,
         }
     }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,8 +1,9 @@
 use http;
+use metadata_map::MetadataMap;
 
 #[derive(Debug)]
 pub struct Request<T> {
-    metadata: http::HeaderMap,
+    metadata: MetadataMap,
     message: T,
 }
 
@@ -10,7 +11,7 @@ impl<T> Request<T> {
     /// Create a new gRPC request
     pub fn new(message: T) -> Self {
         Request {
-            metadata: http::HeaderMap::new(),
+            metadata: MetadataMap::new(),
             message,
         }
     }
@@ -26,12 +27,12 @@ impl<T> Request<T> {
     }
 
     /// Get a reference to the custom request metadata.
-    pub fn metadata(&self) -> &http::HeaderMap {
+    pub fn metadata(&self) -> &MetadataMap {
         &self.metadata
     }
 
     /// Get a mutable reference to the request metadata.
-    pub fn metadata_mut(&mut self) -> &mut http::HeaderMap {
+    pub fn metadata_mut(&mut self) -> &mut MetadataMap {
         &mut self.metadata
     }
 
@@ -44,7 +45,7 @@ impl<T> Request<T> {
     pub fn from_http(http: http::Request<T>) -> Self {
         let (head, message) = http.into_parts();
         Request {
-            metadata: head.headers,
+            metadata: MetadataMap::from_headers(head.headers),
             message,
         }
     }
@@ -55,7 +56,7 @@ impl<T> Request<T> {
         *request.version_mut() = http::Version::HTTP_2;
         *request.method_mut() = http::Method::POST;
         *request.uri_mut() = uri;
-        *request.headers_mut() = self.metadata;
+        *request.headers_mut() = self.metadata.into_headers();
 
         request
     }

--- a/tower-grpc-examples/src/metadata/client.rs
+++ b/tower-grpc-examples/src/metadata/client.rs
@@ -54,7 +54,7 @@ pub fn main() {
                 message: "Hello! Can I come in?".to_string(),
             });
 
-            request.headers_mut().insert("metadata", "Here is a cookie".parse().unwrap());
+            request.metadata_mut().insert("metadata", "Here is a cookie".parse().unwrap());
 
             client.ask_to_enter(request).map_err(|e| panic!("gRPC request failed; err={:?}", e))
         })

--- a/tower-grpc-examples/src/metadata/server.rs
+++ b/tower-grpc-examples/src/metadata/server.rs
@@ -33,7 +33,7 @@ impl server::Doorman for Door {
         println!("REQUEST = {:?}", request);
 
         let metadata = request
-            .headers()
+            .metadata()
             .get("metadata")
             .and_then(|header| header.to_str().ok());
 

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -22,7 +22,7 @@ use std::fmt;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
-use http::header::HeaderValue;
+use tower_grpc::metadata::MetadataValue;
 use http::uri::{self, Uri};
 use futures::{future, Future, stream, Stream};
 use tokio_core::reactor;
@@ -389,7 +389,7 @@ impl TestClients {
         };
         let mut req = Request::new(req);
         req.metadata_mut()
-            .insert(" x-user-ip", HeaderValue::from_static("1.2.3.4"));
+            .insert(" x-user-ip", MetadataValue::from_static("1.2.3.4"));
         // core.run(client.unary_call(req)
         //     .then(|result| {
         //         unimplemented!()

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -388,7 +388,7 @@ impl TestClients {
             ..Default::default()
         };
         let mut req = Request::new(req);
-        req.headers_mut()
+        req.metadata_mut()
             .insert(" x-user-ip", HeaderValue::from_static("1.2.3.4"));
         // core.run(client.unary_call(req)
         //     .then(|result| {


### PR DESCRIPTION
As per the discussion in #90, it wraps http::HeaderMap to abstract away the fact that tower-grpc is HTTP based. At this time this class is a pure wrapper that does not actually implement any of the gRPC metadata specific stuff (such as binary fields), that will come later.

My goal with this PR is to make `MetadataMap` (largely) equivalent to `HeaderMap` while not exposing http types.
