### PR TITLE
Remove required dependency on tower-h2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 license = "MIT"
 
 [features]
-default = ["protobuf"]
+default = ["protobuf", "tower-h2"]
 protobuf = ["prost"]
 
 [workspace]
@@ -31,7 +31,8 @@ futures = "0.1"
 http = "0.1"
 h2 = "0.1.11"
 log = "0.4"
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
+tower-h2 = { git = "https://github.com/tower-rs/tower-h2", optional = true }
+tower-http = { git = "https://github.com/tower-rs/tower-http" }
 tower-service = { git = "https://github.com/tower-rs/tower"  }
 
 # For protobuf
@@ -45,3 +46,4 @@ tokio-core = "0.1"
 # For examples
 prost = "0.4"
 prost-derive = "0.4"
+

--- a/src/body.rs
+++ b/src/body.rs
@@ -1,0 +1,113 @@
+use std::fmt;
+
+use bytes::{Bytes, IntoBuf};
+use futures::Poll;
+use http;
+
+/// A body to send and receive gRPC messages.
+pub trait Body {
+    /// The body buffer type.
+    type Data: IntoBuf;
+
+    /// Returns `true` when the end of the stream has been reached.
+    ///
+    /// An end of stream means that both `poll_data` and `poll_metadata` will
+    /// return `None`.
+    ///
+    /// A return value of `false` **does not** guarantee tht a value will be
+    /// returned from `poll_data` or `poll_trailers. This is merely a hint.
+    fn is_end_stream(&self) -> bool {
+        false
+    }
+
+    /// Polls the stream for more data.
+    fn poll_data(&mut self) -> Poll<Option<Self::Data>, ::Error>;
+
+    /// Polls the stream for the ending metadata.
+    fn poll_metadata(&mut self) -> Poll<Option<http::HeaderMap>, ::Error>;
+}
+
+/// Dynamic `Send` body object.
+pub struct BoxBody<T = Bytes> {
+    inner: Box<Body<Data = T> + Send>,
+}
+
+// ===== impl BoxBody =====
+
+impl<T> BoxBody<T> {
+    /// Create a new `BoxBody` backed by `inner`.
+    pub fn new(inner: Box<Body<Data = T> + Send>) -> Self {
+        BoxBody {
+            inner,
+        }
+    }
+}
+
+impl<T> Body for BoxBody<T>
+where
+    T: IntoBuf,
+{
+    type Data = T;
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn poll_data(&mut self) -> Poll<Option<Self::Data>, ::Error> {
+        self.inner.poll_data()
+    }
+
+    fn poll_metadata(&mut self) -> Poll<Option<http::HeaderMap>, ::Error> {
+        self.inner.poll_metadata()
+    }
+}
+
+#[cfg(feature = "tower-h2")]
+impl<T> ::tower_h2::Body for BoxBody<T>
+where
+    T: IntoBuf + 'static,
+{
+    type Data = T;
+
+    fn is_end_stream(&self) -> bool {
+        Body::is_end_stream(self)
+    }
+
+    fn poll_data(&mut self) -> Poll<Option<Self::Data>, ::h2::Error> {
+        Body::poll_data(self)
+            .map_err(::h2::Error::from)
+    }
+
+    fn poll_trailers(&mut self) -> Poll<Option<http::HeaderMap>, ::h2::Error> {
+        Body::poll_metadata(self)
+            .map_err(::h2::Error::from)
+    }
+}
+
+impl<T> fmt::Debug for BoxBody<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("BoxBody")
+            .finish()
+    }
+}
+
+// ===== impl tower_h2::RecvBody =====
+
+#[cfg(feature = "tower-h2")]
+impl Body for ::tower_h2::RecvBody {
+    type Data = Bytes;
+
+    fn is_end_stream(&self) -> bool {
+        ::tower_h2::Body::is_end_stream(self)
+    }
+
+    fn poll_data(&mut self) -> Poll<Option<Self::Data>, ::Error> {
+        let data = try_ready!(::tower_h2::Body::poll_data(self));
+        Ok(data.map(Bytes::from).into())
+    }
+
+    fn poll_metadata(&mut self) -> Poll<Option<http::HeaderMap>, ::Error> {
+        ::tower_h2::Body::poll_trailers(self)
+            .map_err(::Error::from)
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -6,7 +6,9 @@ pub mod streaming;
 use futures::{stream, Stream, Poll};
 use http::{uri, Uri};
 use prost::Message;
-use tower_h2::{HttpService, BoxBody};
+use tower_http::HttpService;
+
+use body::{Body, BoxBody};
 
 #[derive(Debug)]
 pub struct Grpc<T> {
@@ -41,6 +43,7 @@ impl<T> Grpc<T> {
         -> unary::ResponseFuture<M2, T::Future, T::ResponseBody>
     where
         T: HttpService<R>,
+        T::ResponseBody: Body,
         unary::Once<M1>: Encodable<R>,
     {
         let request = request.map(|v| stream::once(Ok(v)));
@@ -55,6 +58,7 @@ impl<T> Grpc<T> {
         -> client_streaming::ResponseFuture<M, T::Future, T::ResponseBody>
     where
         T: HttpService<R>,
+        T::ResponseBody: Body,
         B: Encodable<R>,
     {
         let response = self.streaming(request, path);

--- a/src/client/server_streaming.rs
+++ b/src/client/server_streaming.rs
@@ -1,10 +1,10 @@
+use Body;
 use super::streaming;
-use codec::Streaming;
+use codec::{Streaming};
 
 use futures::{Future, Poll};
 use http::Response;
 use prost::Message;
-use tower_h2::{Body, Data};
 
 #[derive(Debug)]
 pub struct ResponseFuture<T, U> {
@@ -21,7 +21,7 @@ impl<T, U> ResponseFuture<T, U> {
 impl<T, U, B> Future for ResponseFuture<T, U>
 where T: Message + Default,
       U: Future<Item = Response<B>>,
-      B: Body<Data = Data>,
+      B: Body,
 {
     type Item = ::Response<Streaming<T, B>>;
     type Error = ::Error<U::Error>;

--- a/src/client/streaming.rs
+++ b/src/client/streaming.rs
@@ -1,9 +1,9 @@
+use Body;
 use codec::{Direction, Streaming};
 
 use futures::{Future, Poll};
 use http::Response;
 use prost::Message;
-use tower_h2::{Body, Data};
 
 use Code;
 use status::infer_grpc_status;
@@ -29,7 +29,7 @@ impl<T, U> ResponseFuture<T, U> {
 impl<T, U, B> Future for ResponseFuture<T, U>
 where T: Message + Default,
       U: Future<Item = Response<B>>,
-      B: Body<Data = Data>,
+      B: Body,
 {
     type Item = ::Response<Streaming<T, B>>;
     type Error = ::Error<U::Error>;

--- a/src/client/unary.rs
+++ b/src/client/unary.rs
@@ -1,18 +1,20 @@
+use Body;
 use super::client_streaming;
 
+use std::fmt;
+
+use bytes::IntoBuf;
 use futures::{stream, Future, Poll};
 use http::{Response};
 use prost::Message;
-use tower_h2::{Body, Data};
 
-#[derive(Debug)]
-pub struct ResponseFuture<T, U, B> {
+pub struct ResponseFuture<T, U, B: Body> {
     inner: client_streaming::ResponseFuture<T, U, B>,
 }
 
 pub type Once<T> = stream::Once<T, ::Error>;
 
-impl<T, U, B> ResponseFuture<T, U, B> {
+impl<T, U, B: Body> ResponseFuture<T, U, B> {
     /// Create a new client-streaming response future.
     pub(crate) fn new(inner: client_streaming::ResponseFuture<T, U, B>) -> Self {
         ResponseFuture { inner }
@@ -22,12 +24,26 @@ impl<T, U, B> ResponseFuture<T, U, B> {
 impl<T, U, B> Future for ResponseFuture<T, U, B>
 where T: Message + Default,
       U: Future<Item = Response<B>>,
-      B: Body<Data = Data>,
+      B: Body,
 {
     type Item = ::Response<T>;
     type Error = ::Error<U::Error>;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         self.inner.poll()
+    }
+}
+
+impl<T, U, B> fmt::Debug for ResponseFuture<T, U, B>
+where
+    T: fmt::Debug,
+    U: fmt::Debug,
+    B: Body + fmt::Debug,
+    <B::Data as IntoBuf>::Buf: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ResponseFuture")
+            .field("inner", &self.inner)
+            .finish()
     }
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2,7 +2,7 @@
 pub mod server {
     /// Re-export types from this crate
     pub mod grpc {
-        pub use ::{Request, Response, Error, Status};
+        pub use ::{Body, BoxBody, Request, Response, Error, Status};
         pub use ::generic::server::{
             StreamingService,
             UnaryService,
@@ -43,14 +43,15 @@ pub mod server {
         pub use ::h2::Error;
     }
 
-    /// Re-export types from the `tower_h2` crate
-    pub mod tower_h2 {
-        pub use ::tower_h2::{Body, RecvBody};
-    }
-
     /// Re-exported types from the `tower` crate.
     pub mod tower {
-        pub use ::tower_service::{Service, NewService};
+        pub use ::tower_service::{Service, MakeService};
+    }
+
+    #[cfg(feature = "tower-h2")]
+    /// Re-exported types from `tower-h2` crate.
+    pub mod tower_h2 {
+        pub use ::tower_h2::{Body, RecvBody};
     }
 }
 
@@ -65,7 +66,7 @@ pub mod client {
             server_streaming,
             streaming,
         };
-        pub use ::{Request, Response, Error, Status};
+        pub use ::{Body, Request, Response, Error, Status};
     }
 
     pub mod http {
@@ -77,7 +78,13 @@ pub mod client {
         pub use ::futures::{Future, Poll};
     }
 
+    pub mod tower {
+        pub use ::tower_http::HttpService;
+    }
+
+    #[cfg(feature = "tower-h2")]
+    /// Re-exported types from `tower-h2` crate.
     pub mod tower_h2 {
-        pub use ::tower_h2::HttpService;
+        pub use ::tower_h2::Body;
     }
 }

--- a/src/generic/codec.rs
+++ b/src/generic/codec.rs
@@ -1,12 +1,11 @@
-use Status;
+use {Body, Status};
 
-use bytes::{Buf, BufMut, BytesMut, Bytes};
+use bytes::{Buf, BufMut, BytesMut, Bytes, IntoBuf};
 use futures::{Stream, Poll, Async};
-use h2;
 use http::{HeaderMap, StatusCode};
-use tower_h2::{self, Body, Data};
 
 use std::collections::VecDeque;
+use std::fmt;
 
 use status::infer_grpc_status;
 use error::ProtocolError;
@@ -86,16 +85,15 @@ enum EncodeInner<T, U> {
 
 /// An stream of inbound gRPC messages
 #[must_use = "futures do nothing unless polled"]
-#[derive(Debug)]
-pub struct Streaming<T, U = tower_h2::RecvBody> {
+pub struct Streaming<T, B: Body> {
     /// The decoder
     decoder: T,
 
     /// The source of encoded messages
-    inner: U,
+    inner: B,
 
     /// buffer
-    bufs: BytesList,
+    bufs: BufList<<B::Data as IntoBuf>::Buf>,
 
     /// Decoding state
     state: State,
@@ -134,15 +132,14 @@ pub struct EncodeBuf<'a> {
 }
 
 /// A buffer to decode messages from.
-#[derive(Debug)]
 pub struct DecodeBuf<'a> {
-    bufs: &'a mut BytesList,
+    bufs: &'a mut Buf,
     len: usize,
 }
 
 #[derive(Debug)]
-pub struct BytesList {
-    bufs: VecDeque<Bytes>,
+pub struct BufList<B> {
+    bufs: VecDeque<B>,
 }
 
 // ===== impl Encode =====
@@ -168,7 +165,7 @@ where T: Encoder<Item = U::Item>,
     }
 }
 
-impl<T, U> tower_h2::Body for Encode<T, U>
+impl<T, U> Body for Encode<T, U>
 where T: Encoder<Item = U::Item>,
       U: Stream,
 {
@@ -178,17 +175,17 @@ where T: Encoder<Item = U::Item>,
         false
     }
 
-    fn poll_data(&mut self) -> Poll<Option<Self::Data>, h2::Error> {
+    fn poll_data(&mut self) -> Poll<Option<Self::Data>, ::Error> {
         match self.inner {
             EncodeInner::Ok { ref mut inner, ref mut encoder } => {
-                let item = try_ready!(inner.poll().map_err(|_| h2_err()));
+                let item = try_ready!(inner.poll().map_err(|_| ::Error::Inner(())));
 
                 if let Some(item) = item {
                     self.buf.reserve(5);
                     unsafe { self.buf.advance_mut(5); }
                     encoder.encode(item, &mut EncodeBuf {
                         bytes: &mut self.buf,
-                    }).map_err(|_| h2_err())?;
+                    })?;
 
                     // now that we know length, we can write the header
                     let len = self.buf.len() - 5;
@@ -208,7 +205,7 @@ where T: Encoder<Item = U::Item>,
         }
     }
 
-    fn poll_trailers(&mut self) -> Poll<Option<HeaderMap>, h2::Error> {
+    fn poll_metadata(&mut self) -> Poll<Option<HeaderMap>, ::Error> {
         if !self.return_trailers {
             return Ok(Async::Ready(None));
         }
@@ -227,17 +224,39 @@ where T: Encoder<Item = U::Item>,
     }
 }
 
+#[cfg(feature = "tower-h2")]
+impl<T, U> ::tower_h2::Body for Encode<T, U>
+where T: Encoder<Item = U::Item>,
+      U: Stream,
+{
+    type Data = ::bytes::Bytes;
+
+    fn is_end_stream(&self) -> bool {
+        Body::is_end_stream(self)
+    }
+
+    fn poll_data(&mut self) -> Poll<Option<Self::Data>, ::h2::Error> {
+        Body::poll_data(self)
+            .map_err(From::from)
+    }
+
+    fn poll_trailers(&mut self) -> Poll<Option<http::HeaderMap>, ::h2::Error> {
+        Body::poll_metadata(self)
+            .map_err(From::from)
+    }
+}
+
 // ===== impl Streaming =====
 
 impl<T, U> Streaming<T, U>
 where T: Decoder,
-      U: Body<Data = Data>,
+      U: Body,
 {
     pub(crate) fn new(decoder: T, inner: U, direction: Direction) -> Self {
         Streaming {
             decoder,
             inner,
-            bufs: BytesList {
+            bufs: BufList {
                 bufs: VecDeque::new(),
             },
             state: State::ReadHeader,
@@ -295,7 +314,7 @@ where T: Decoder,
 
 impl<T, U> Stream for Streaming<T, U>
 where T: Decoder,
-      U: Body<Data = Data>,
+      U: Body,
 {
     type Item = T::Item;
     type Error = ::Error;
@@ -314,7 +333,7 @@ where T: Decoder,
             let chunk = try_ready!(self.inner.poll_data());
 
             if let Some(data) = chunk {
-                self.bufs.bufs.push_back(data.into());
+                self.bufs.bufs.push_back(data.into_buf());
             } else {
                 if self.bufs.has_remaining() {
                     trace!("unexpected EOF decoding stream");
@@ -327,7 +346,7 @@ where T: Decoder,
         }
 
         if let Direction::Response(status_code) = self.direction {
-            if let Some(trailers) = try_ready!(self.inner.poll_trailers()) {
+            if let Some(trailers) = try_ready!(self.inner.poll_metadata()) {
                 let status = infer_grpc_status(&trailers, Some(status_code))
                     .ok_or(::Error::Protocol(ProtocolError::MissingTrailers))?;
                 if status.code() == ::Code::OK {
@@ -342,6 +361,18 @@ where T: Decoder,
         } else {
             Ok(Async::Ready(None))
         }
+    }
+}
+
+impl<T, B> fmt::Debug for Streaming<T, B>
+where
+    T: fmt::Debug,
+    B: Body + fmt::Debug,
+    <B::Data as IntoBuf>::Buf: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Streaming")
+            .finish()
     }
 }
 
@@ -398,6 +429,13 @@ impl<'a> Buf for DecodeBuf<'a> {
     }
 }
 
+impl<'a> fmt::Debug for DecodeBuf<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("DecodeBuf")
+            .finish()
+    }
+}
+
 impl<'a> Drop for DecodeBuf<'a> {
     fn drop(&mut self) {
         if self.len > 0 {
@@ -407,13 +445,13 @@ impl<'a> Drop for DecodeBuf<'a> {
     }
 }
 
-// ===== impl BytesList =====
+// ===== impl BufList =====
 
-impl Buf for BytesList {
+impl<T: Buf> Buf for BufList<T> {
     #[inline]
     fn remaining(&self) -> usize {
         self.bufs.iter()
-            .map(|buf| buf.len())
+            .map(|buf| buf.remaining())
             .sum()
     }
 
@@ -422,7 +460,7 @@ impl Buf for BytesList {
         if self.bufs.is_empty() {
             &[]
         } else {
-            &self.bufs[0][..]
+            self.bufs[0].bytes()
         }
     }
 
@@ -431,11 +469,11 @@ impl Buf for BytesList {
         while cnt > 0 {
             {
                 let front = &mut self.bufs[0];
-                if front.len() > cnt {
+                if front.remaining() > cnt {
                     front.advance(cnt);
                     return;
                 } else {
-                    cnt -= front.len();
+                    cnt -= front.remaining();
                 }
             }
             self.bufs.pop_front();
@@ -443,8 +481,3 @@ impl Buf for BytesList {
     }
 }
 
-// ===== impl utils =====
-
-fn h2_err() -> h2::Error {
-    unimplemented!("EncodingBody map_err")
-}

--- a/src/generic/server/grpc.rs
+++ b/src/generic/server/grpc.rs
@@ -1,10 +1,9 @@
-use ::Request;
+use {Body, Request};
 use super::{streaming, server_streaming, client_streaming, unary};
 use generic::{Codec, Direction, Streaming};
 use generic::server::{StreamingService, ServerStreamingService, ClientStreamingService, UnaryService};
 
 use http;
-use tower_h2::{Body, Data};
 
 #[derive(Debug, Clone)]
 pub struct Grpc<T> {
@@ -26,7 +25,7 @@ where T: Codec,
         -> unary::ResponseFuture<S, T::Encoder, Streaming<T::Decoder, B>>
     where S: UnaryService<T::Decode,
                          Response = T::Encode>,
-          B: Body<Data = Data>,
+          B: Body,
     {
         let request = self.map_request(request);
         unary::ResponseFuture::new(service, request, self.codec.encoder())
@@ -38,7 +37,7 @@ where T: Codec,
         -> client_streaming::ResponseFuture<S::Future, T::Encoder>
     where S: ClientStreamingService<Streaming<T::Decoder, B>,
                                    Response = T::Encode>,
-          B: Body<Data = Data>,
+          B: Body,
     {
         let response = service.call(self.map_request(request));
         client_streaming::ResponseFuture::new(response, self.codec.encoder())
@@ -50,7 +49,7 @@ where T: Codec,
         -> server_streaming::ResponseFuture<S, T::Encoder, Streaming<T::Decoder, B>>
     where S: ServerStreamingService<T::Decode,
                                    Response = T::Encode>,
-          B: Body<Data = Data>,
+          B: Body,
     {
         let request = self.map_request(request);
         server_streaming::ResponseFuture::new(service, request, self.codec.encoder())
@@ -62,7 +61,7 @@ where T: Codec,
         -> streaming::ResponseFuture<S::Future, T::Encoder>
     where S: StreamingService<Streaming<T::Decoder, B>,
                               Response = T::Encode>,
-          B: Body<Data = Data>,
+          B: Body,
     {
         let response = service.call(self.map_request(request));
         streaming::ResponseFuture::new(response, self.codec.encoder())
@@ -71,7 +70,7 @@ where T: Codec,
     /// Map an inbound HTTP request to a streaming decoded request
     fn map_request<B>(&mut self, request: http::Request<B>)
         -> Request<Streaming<T::Decoder, B>>
-    where B: Body<Data = Data>,
+    where B: Body,
     {
         // Map the request body
         let (head, body) = request.into_parts();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,20 +8,24 @@ extern crate http;
 extern crate h2;
 #[macro_use]
 extern crate log;
-extern crate tower_h2;
+extern crate tower_http;
 extern crate tower_service;
 
+#[cfg(feature = "tower-h2")]
+extern crate tower_h2;
 #[cfg(feature = "protobuf")]
 extern crate prost;
 
 pub mod client;
 pub mod generic;
 
+mod body;
 mod error;
 mod request;
 mod response;
 mod status;
 
+pub use body::{Body, BoxBody};
 pub use error::{Error, ProtocolError};
 pub use status::{Code, Status};
 pub use request::Request;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,12 +3,12 @@ pub mod server_streaming;
 pub mod streaming;
 pub mod unary;
 
+use Body;
 use codec::{Codec, Streaming};
 use generic::server::{UnaryService, ClientStreamingService, ServerStreamingService, StreamingService};
 
 use http;
 use prost;
-use tower_h2::{Body, Data};
 
 #[derive(Debug, Clone)]
 pub struct Grpc {
@@ -24,7 +24,7 @@ impl Grpc {
     where T: UnaryService<R>,
           R: prost::Message + Default,
           T::Response: prost::Message,
-          B: Body<Data = Data>,
+          B: Body,
     {
         use generic::server::Grpc;
 
@@ -39,7 +39,7 @@ impl Grpc {
     where T: ClientStreamingService<Streaming<R, B>>,
           R: prost::Message + Default,
           T::Response: prost::Message,
-          B: Body<Data = Data>,
+          B: Body,
     {
         use generic::server::Grpc;
 
@@ -54,7 +54,7 @@ impl Grpc {
     where T: ServerStreamingService<R>,
           R: prost::Message + Default,
           T::Response: prost::Message,
-          B: Body<Data = Data>,
+          B: Body,
     {
         use generic::server::Grpc;
 
@@ -69,7 +69,7 @@ impl Grpc {
     where T: StreamingService<Streaming<R, B>>,
           R: prost::Message + Default,
           T::Response: prost::Message,
-          B: Body<Data = Data>,
+          B: Body,
     {
         use generic::server::Grpc;
 

--- a/src/server/server_streaming.rs
+++ b/src/server/server_streaming.rs
@@ -1,16 +1,17 @@
+use Body;
 use codec::{Encode, Encoder, Streaming};
 use generic::server::{ServerStreamingService, server_streaming};
 
 use std::fmt;
 
+use bytes::IntoBuf;
 use {h2, http, prost};
 use futures::{Future, Poll};
-use tower_h2::{Body, Data};
 
 pub struct ResponseFuture<T, B, R>
 where
     T: ServerStreamingService<R>,
-    B: Body<Data = Data>,
+    B: Body,
     R: prost::Message + Default,
 {
     inner: Inner<T, T::Response, R, B>,
@@ -23,7 +24,7 @@ impl<T, B, R> ResponseFuture<T, B, R>
 where T: ServerStreamingService<R>,
       R: prost::Message + Default,
       T::Response: prost::Message,
-      B: Body<Data = Data>,
+      B: Body,
 {
     pub(crate) fn new(inner: Inner<T, T::Response, R, B>) -> Self {
         ResponseFuture { inner }
@@ -34,7 +35,7 @@ impl<T, B, R> Future for ResponseFuture<T, B, R>
 where T: ServerStreamingService<R>,
       R: prost::Message + Default,
       T::Response: prost::Message,
-      B: Body<Data = Data>,
+      B: Body,
 {
     type Item = http::Response<Encode<T::ResponseStream>>;
     type Error = h2::Error;
@@ -52,7 +53,8 @@ where T: ServerStreamingService<R> + fmt::Debug,
       T::Response: fmt::Debug,
       T::ResponseStream: fmt::Debug,
       T::Future: fmt::Debug,
-      B: Body<Data = Data> + fmt::Debug,
+      B: Body + fmt::Debug,
+      <B::Data as IntoBuf>::Buf: fmt::Debug,
       R: prost::Message + Default,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {

--- a/tower-grpc-build/Cargo.toml
+++ b/tower-grpc-build/Cargo.toml
@@ -8,3 +8,7 @@ license = "MIT"
 codegen = { git = "https://github.com/carllerche/codegen" }
 prost-build = "0.4"
 heck = "0.3"
+
+[features]
+default = ["tower-h2"]
+tower-h2 = []

--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -74,7 +74,7 @@ impl ServiceGenerator {
 
         imp.new_fn("poll_ready")
             .generic("R")
-            .bound("T", "tower_h2::HttpService<R>")
+            .bound("T", "tower::HttpService<R>")
             .vis("pub")
             .arg_mut_self()
             .ret("futures::Poll<(), grpc::Error<T::Error>>")
@@ -90,7 +90,8 @@ impl ServiceGenerator {
             let func = imp.new_fn(&name)
                 .vis("pub")
                 .generic("R")
-                .bound("T", "tower_h2::HttpService<R>")
+                .bound("T", "tower::HttpService<R>")
+                .bound("T::ResponseBody", "grpc::Body")
                 .arg_mut_self()
                 .line(format!("let path = http::PathAndQuery::from_static({});", path))
                 ;

--- a/tower-grpc-examples/Cargo.toml
+++ b/tower-grpc-examples/Cargo.toml
@@ -48,6 +48,3 @@ serde_derive = "1.0"
 
 [build-dependencies]
 tower-grpc-build = { path = "../tower-grpc-build" }
-
-[patch.crates-io]
-http = { git = "http://github.com/hyperium/http", rev = "5f362a32278891672f428d570d46387fe6896a5d" }

--- a/tower-grpc-examples/src/helloworld/server.rs
+++ b/tower-grpc-examples/src/helloworld/server.rs
@@ -53,7 +53,7 @@ pub fn main() {
     let bind = TcpListener::bind(&addr, &reactor).expect("bind");
 
     let serve = bind.incoming()
-        .fold((h2, reactor), |(h2, reactor), (sock, _)| {
+        .fold((h2, reactor), |(mut h2, reactor), (sock, _)| {
             if let Err(e) = sock.set_nodelay(true) {
                 return Err(e);
             }

--- a/tower-grpc-examples/src/metadata/server.rs
+++ b/tower-grpc-examples/src/metadata/server.rs
@@ -63,7 +63,7 @@ pub fn main() {
 
     let serve = bind
         .incoming()
-        .fold((h2, reactor), |(h2, reactor), (sock, _)| {
+        .fold((h2, reactor), |(mut h2, reactor), (sock, _)| {
             if let Err(e) = sock.set_nodelay(true) {
                 return Err(e);
             }

--- a/tower-grpc-examples/src/routeguide/server.rs
+++ b/tower-grpc-examples/src/routeguide/server.rs
@@ -257,7 +257,7 @@ pub fn main() {
     println!("listining on {:?}", addr);
 
     let serve = bind.incoming()
-        .fold((h2, reactor), |(h2, reactor), (sock, _)| {
+        .fold((h2, reactor), |(mut h2, reactor), (sock, _)| {
             if let Err(e) = sock.set_nodelay(true) {
                 return Err(e);
             }

--- a/tower-grpc-interop/Cargo.toml
+++ b/tower-grpc-interop/Cargo.toml
@@ -29,6 +29,3 @@ domain = "0.2.2"
 
 [build-dependencies]
 tower-grpc-build = { path = "../tower-grpc-build" }
-
-[patch.crates-io]
-http = { git = "http://github.com/hyperium/http", rev = "5f362a32278891672f428d570d46387fe6896a5d" }

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -227,14 +227,14 @@ struct TestClients {
             tower_h2::client::Connection<
                 tokio_core::net::TcpStream,
                 tokio_core::reactor::Handle,
-                tower_h2::BoxBody>>>,
+                tower_grpc::BoxBody>>>,
 
     unimplemented_client:
         UnimplementedService<tower_http::AddOrigin<
             tower_h2::client::Connection<
                 tokio_core::net::TcpStream,
                 tokio_core::reactor::Handle,
-                tower_h2::BoxBody>>>
+                tower_grpc::BoxBody>>>
 }
 
 fn make_ping_pong_request(idx: usize) -> pb::StreamingOutputCallRequest {
@@ -397,7 +397,10 @@ impl TestClients {
         // )
         unimplemented!();
         // This line is just a hint for the type checker
+        #[allow(unreachable_code)]
+        {
         future::ok::<Vec<TestAssertion>, Box<Error>>(vec![])
+        }
     }
 
     fn client_streaming_test(&mut self)


### PR DESCRIPTION
- Uses `HttpService` from `tower-http`.
- Defines its own `Body` trait to be generic over.
- Adds a `tower-h2` feature to both `tower-grpc` and `tower-grpc-build`,
  which if enabled, will provide impls for `tower-h2` types. This allows
  the examples and interop to still work.