### PR TITLE
Expose extensions map in Request

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -3,6 +3,7 @@ use http;
 #[derive(Debug)]
 pub struct Request<T> {
     headers: http::HeaderMap,
+    extensions: http::Extensions,
     message: T,
 }
 
@@ -11,6 +12,7 @@ impl<T> Request<T> {
     pub fn new(message: T) -> Self {
         Request {
             headers: http::HeaderMap::new(),
+            extensions: http::Extensions::new(),
             message,
         }
     }
@@ -35,6 +37,16 @@ impl<T> Request<T> {
         &mut self.headers
     }
 
+    /// Get a reference to the request extensions.
+    pub fn extensions(&self) -> &http::Extensions {
+        &self.extensions
+    }
+
+    /// Get a mutable reference to the request extensions.
+    pub fn extensions_mut(&mut self) -> &mut http::Extensions {
+        &mut self.extensions
+    }
+
     /// Consumes `self`, returning the message
     pub fn into_inner(self) -> T {
         self.message
@@ -45,6 +57,7 @@ impl<T> Request<T> {
         let (head, message) = http.into_parts();
         Request {
             headers: head.headers,
+            extensions: head.extensions,
             message,
         }
     }
@@ -56,6 +69,7 @@ impl<T> Request<T> {
         *request.method_mut() = http::Method::POST;
         *request.uri_mut() = uri;
         *request.headers_mut() = self.headers;
+        *request.extensions_mut() = self.extensions;
 
         request
     }
@@ -67,6 +81,7 @@ impl<T> Request<T> {
 
         Request {
             headers: self.headers,
+            extensions: self.extensions,
             message,
         }
     }


### PR DESCRIPTION
### Added

* Add `extensions()` and `extensions_mut()` methods to `Request`.

This is handy for storing extra metadata alongside a `Request` which can be processed in the server implementation. Closes #94.