### PR TITLE
Fix missing dyn in tower-grpc-build to satisfy rust 2018 idioms

### DIFF
--- a/tower-grpc-build/src/server.rs
+++ b/tower-grpc-build/src/server.rs
@@ -292,7 +292,7 @@ macro_rules! try_ready {
             imp.new_fn("poll_ready")
                 .arg_mut_self()
                 .ret("futures::Poll<(), Self::Error>")
-                .line("<tower::Service<http::Request<grpc::BoxBody>, Response=_, Error=_, Future=_>>::poll_ready(self)")
+                .line("tower::Service::<http::Request<grpc::BoxBody>>::poll_ready(self)")
                 ;
 
             imp.new_fn("call")
@@ -300,7 +300,7 @@ macro_rules! try_ready {
                 .arg("request", "http::Request<tower_h2::RecvBody>")
                 .ret("Self::Future")
                 .line("let request = request.map(|b| grpc::BoxBody::new(Box::new(b)));")
-                .line("<tower::Service<http::Request<grpc::BoxBody>, Response=_, Error=_, Future=_>>::call(self, request)")
+                .line("tower::Service::<http::Request<grpc::BoxBody>>::call(self, request)")
                 ;
         }
     }


### PR DESCRIPTION
When I compile my code using `tower-grpc-build` with these rust 2018 attributes:

```rust
#![warn(rust_2018_compatibility)]
#![warn(rust_2018_idioms)]
```

it produces a warning about not explicitly using `dyn`.


```bash
warning: trait objects without an explicit `dyn` are deprecated
   --> /Users/lucio/code/clique/target/debug/build/clique-a263e5c7d647a25f/out/clique.proto.rs:138:14
    |
138 |             <tower::Service<http::Request<grpc::BoxBody>, Response=_, Error=_, Future=_>>::poll_ready(self)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn tower::Service<http::Request<grpc::BoxBody>, Response=_, Error=_, Future=_>`
    |
note: lint level defined here
   --> src/lib.rs:6:9
    |
6   | #![warn(rust_2018_idioms)]
    |         ^^^^^^^^^^^^^^^^
    = note: #[warn(bare_trait_objects)] implied by #[warn(rust_2018_idioms)]

warning: trait objects without an explicit `dyn` are deprecated
   --> /Users/lucio/code/clique/target/debug/build/clique-a263e5c7d647a25f/out/clique.proto.rs:143:14
    |
143 |             <tower::Service<http::Request<grpc::BoxBody>, Response=_, Error=_, Future=_>>::call(self, request)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn tower::Service<http::Request<grpc::BoxBody>, Response=_, Error=_, Future=_>`
```

This change fixes this warning.