### PR TITLE
Request metadata bin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
 ]
 
 [dependencies]
+base64 = "0.10"
 bytes = "0.4.7"
 futures = "0.1"
 http = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ pub mod metadata {
     pub use metadata_key::AsciiMetadataKey;
     pub use metadata_key::BinaryMetadataKey;
     pub use metadata_key::MetadataKey;
+    pub use metadata_value::AsciiMetadataValue;
+    pub use metadata_value::BinaryMetadataValue;
     pub use metadata_value::MetadataValue;
     pub use metadata_map::MetadataMap;
     pub use metadata_map::Iter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,10 @@ pub use response::Response;
 /// The metadata module contains data structures and utilities for handling
 /// gRPC custom metadata.
 pub mod metadata {
+    pub use metadata_key::Ascii;
+    pub use metadata_key::AsciiMetadataKey;
+    pub use metadata_key::Binary;
+    pub use metadata_key::BinaryMetadataKey;
     pub use metadata_key::MetadataKey;
     pub use metadata_value::MetadataValue;
     pub use metadata_map::MetadataMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub mod metadata {
     pub use metadata_map::KeyAndMutValueRef;
     pub use metadata_map::Values;
     pub use metadata_map::ValueRef;
+    pub use metadata_map::ValueRefMut;
     pub use metadata_map::ValueIter;
     pub use metadata_map::GetAll;
     pub use metadata_map::Entry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod metadata {
     pub use metadata_map::Keys;
     pub use metadata_map::KeyRef;
     pub use metadata_map::KeyAndValueRef;
+    pub use metadata_map::KeyAndMutValueRef;
     pub use metadata_map::Values;
     pub use metadata_map::ValueRef;
     pub use metadata_map::ValueIter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod metadata {
     pub use metadata_map::Iter;
     pub use metadata_map::ValueDrain;
     pub use metadata_map::Keys;
+    pub use metadata_map::KeyAndValueRef;
     pub use metadata_map::Values;
     pub use metadata_map::ValueIter;
     pub use metadata_map::GetAll;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@ pub mod metadata {
     pub use metadata_map::MetadataMap;
     pub use metadata_map::Iter;
     pub use metadata_map::ValueDrain;
-    pub use metadata_map::Drain;
     pub use metadata_map::Keys;
     pub use metadata_map::Values;
     pub use metadata_map::ValueIter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,8 +67,8 @@ pub mod metadata {
     /// while handling gRPC custom metadata.
     pub mod errors {
         pub use metadata_key::InvalidMetadataKey;
-        pub use metadata_value::InvalidMetadataValue;
-        pub use metadata_value::InvalidMetadataValueBytes;
+        pub use metadata_encoding::InvalidMetadataValue;
+        pub use metadata_encoding::InvalidMetadataValueBytes;
         pub use metadata_value::ToStrError;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod generic;
 
 mod body;
 mod error;
+mod metadata_encoding;
 mod metadata_key;
 mod metadata_value;
 mod metadata_map;
@@ -38,9 +39,9 @@ pub use response::Response;
 /// The metadata module contains data structures and utilities for handling
 /// gRPC custom metadata.
 pub mod metadata {
-    pub use metadata_key::Ascii;
+    pub use metadata_encoding::Ascii;
+    pub use metadata_encoding::Binary;
     pub use metadata_key::AsciiMetadataKey;
-    pub use metadata_key::Binary;
     pub use metadata_key::BinaryMetadataKey;
     pub use metadata_key::MetadataKey;
     pub use metadata_value::MetadataValue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(warnings, missing_debug_implementations)]
 //#![deny(missing_docs)]
 
+extern crate base64;
 extern crate bytes;
 #[macro_use]
 extern crate futures;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,10 @@ pub mod metadata {
     pub use metadata_map::Iter;
     pub use metadata_map::ValueDrain;
     pub use metadata_map::Keys;
+    pub use metadata_map::KeyRef;
     pub use metadata_map::KeyAndValueRef;
     pub use metadata_map::Values;
+    pub use metadata_map::ValueRef;
     pub use metadata_map::ValueIter;
     pub use metadata_map::GetAll;
     pub use metadata_map::Entry;

--- a/src/metadata_encoding.rs
+++ b/src/metadata_encoding.rs
@@ -1,9 +1,16 @@
+use bytes::Bytes;
 use std::hash::Hash;
 
 // TODO(pgron): Make sealed
 pub trait ValueEncoding: Clone + Eq + PartialEq + Hash {
     #[doc(hidden)]
     fn is_valid_key(key: &str) -> bool;
+
+    #[doc(hidden)]
+    fn is_empty(value: &[u8]) -> bool;
+
+    #[doc(hidden)]
+    fn encode(value: Bytes) -> Bytes;
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -15,10 +22,28 @@ impl ValueEncoding for Ascii {
     fn is_valid_key(key: &str) -> bool {
         !Binary::is_valid_key(key)
     }
+
+    fn is_empty(value: &[u8]) -> bool {
+        value.is_empty()
+    }
+
+    fn encode(value: Bytes) -> Bytes {
+       value
+    }
 }
 
 impl ValueEncoding for Binary {
     fn is_valid_key(key: &str) -> bool {
         key.ends_with("-bin")
+    }
+
+    fn is_empty(value: &[u8]) -> bool {
+        // TODO(pgron): Do this properly for base64
+        value.is_empty()
+    }
+
+    fn encode(value: Bytes) -> Bytes {
+        // TODO(pgron): Do this properly for base64
+        value
     }
 }

--- a/src/metadata_encoding.rs
+++ b/src/metadata_encoding.rs
@@ -1,0 +1,24 @@
+use std::hash::Hash;
+
+// TODO(pgron): Make sealed
+pub trait ValueEncoding: Clone + Eq + PartialEq + Hash {
+    #[doc(hidden)]
+    fn is_valid_key(key: &str) -> bool;
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct Ascii {}
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct Binary {}
+
+impl ValueEncoding for Ascii {
+    fn is_valid_key(key: &str) -> bool {
+        !Binary::is_valid_key(key)
+    }
+}
+
+impl ValueEncoding for Binary {
+    fn is_valid_key(key: &str) -> bool {
+        key.ends_with("-bin")
+    }
+}

--- a/src/metadata_encoding.rs
+++ b/src/metadata_encoding.rs
@@ -11,7 +11,6 @@ pub struct InvalidMetadataValue {
     _priv: (),
 }
 
-// TODO(pgron): Make sealed
 pub trait ValueEncoding: Clone + Eq + PartialEq + Hash {
     #[doc(hidden)]
     fn is_valid_key(key: &str) -> bool;

--- a/src/metadata_encoding.rs
+++ b/src/metadata_encoding.rs
@@ -21,6 +21,9 @@ pub trait ValueEncoding: Clone + Eq + PartialEq + Hash {
 
     #[doc(hidden)]
     fn from_shared(value: Bytes) -> Result<HeaderValue, InvalidMetadataValueBytes>;
+
+    #[doc(hidden)]
+    fn decode(value: &[u8]) -> Result<Bytes, InvalidMetadataValueBytes>;
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -45,6 +48,11 @@ impl ValueEncoding for Ascii {
                 InvalidMetadataValueBytes::new()
             })
     }
+
+    #[doc(hidden)]
+    fn decode(value: &[u8]) -> Result<Bytes, InvalidMetadataValueBytes> {
+        Ok(Bytes::from(value))
+    }
 }
 
 impl ValueEncoding for Binary {
@@ -63,6 +71,12 @@ impl ValueEncoding for Binary {
             .map_err(|_| {
                 InvalidMetadataValueBytes::new()
             })
+    }
+
+    #[doc(hidden)]
+    fn decode(value: &[u8]) -> Result<Bytes, InvalidMetadataValueBytes> {
+        // TODO(pgron): Do this properly for base64
+        Ok(Bytes::from(value))
     }
 }
 

--- a/src/metadata_encoding.rs
+++ b/src/metadata_encoding.rs
@@ -61,8 +61,12 @@ impl ValueEncoding for Binary {
     }
 
     fn is_empty(value: &[u8]) -> bool {
-        // TODO(pgron): Do this properly for base64
-        value.is_empty()
+        for c in value {
+            if *c != b'=' {
+                return false;
+            }
+        }
+        return true;
     }
 
     fn from_shared(value: Bytes) -> Result<HeaderValue, InvalidMetadataValueBytes> {

--- a/src/metadata_key.rs
+++ b/src/metadata_key.rs
@@ -1,36 +1,15 @@
 use bytes::Bytes;
 use http;
 use http::header::HeaderName;
+use metadata_encoding::Ascii;
+use metadata_encoding::Binary;
+use metadata_encoding::ValueEncoding;
 
 use std::borrow::Borrow;
 use std::error::Error;
 use std::fmt;
-use std::hash::Hash;
 use std::marker::PhantomData;
 use std::str::FromStr;
-
-// TODO(pgron): Make sealed
-pub trait ValueEncoding: Clone + Eq + PartialEq + Hash {
-    #[doc(hidden)]
-    fn is_valid_key(key: &str) -> bool;
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub struct Ascii {}
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub struct Binary {}
-
-impl ValueEncoding for Ascii {
-    fn is_valid_key(key: &str) -> bool {
-        !Binary::is_valid_key(key)
-    }
-}
-
-impl ValueEncoding for Binary {
-    fn is_valid_key(key: &str) -> bool {
-        key.ends_with("-bin")
-    }
-}
 
 /// Represents a custom metadata field name.
 ///

--- a/src/metadata_key.rs
+++ b/src/metadata_key.rs
@@ -1,15 +1,16 @@
 use bytes::Bytes;
 use http;
 use http::header::HeaderName;
-use metadata_encoding::Ascii;
-use metadata_encoding::Binary;
-use metadata_encoding::ValueEncoding;
 
 use std::borrow::Borrow;
 use std::error::Error;
 use std::fmt;
 use std::marker::PhantomData;
 use std::str::FromStr;
+
+use metadata_encoding::Ascii;
+use metadata_encoding::Binary;
+use metadata_encoding::ValueEncoding;
 
 /// Represents a custom metadata field name.
 ///

--- a/src/metadata_map.rs
+++ b/src/metadata_map.rs
@@ -12,8 +12,6 @@ pub use self::as_metadata_key::AsMetadataKey;
 pub use self::as_encoding_agnostic_metadata_key::AsEncodingAgnosticMetadataKey;
 pub use self::into_metadata_key::IntoMetadataKey;
 
-// TODO(pgron): Implement the actual base64 encoding and decoding for -bin entries.
-
 /// A set of gRPC custom metadata entries.
 ///
 /// # Examples

--- a/src/metadata_map.rs
+++ b/src/metadata_map.rs
@@ -26,7 +26,7 @@ pub use self::into_metadata_key::IntoMetadataKey;
 ///
 /// map.insert("x-host", "example.com".parse().unwrap());
 /// map.insert("x-number", "123".parse().unwrap());
-/// map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"[binary data]").unwrap());
+/// map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"[binary data]"));
 ///
 /// assert!(map.contains_key("x-host"));
 /// assert!(!map.contains_key("x-location"));
@@ -273,7 +273,7 @@ impl MetadataMap {
     /// assert_eq!(0, map.len());
     ///
     /// map.insert("x-host-ip", "127.0.0.1".parse().unwrap());
-    /// map.insert_bin("x-host-name-bin", MetadataValue::from_bytes(b"localhost").unwrap());
+    /// map.insert_bin("x-host-name-bin", MetadataValue::from_bytes(b"localhost"));
     ///
     /// assert_eq!(2, map.len());
     ///
@@ -299,7 +299,7 @@ impl MetadataMap {
     /// assert_eq!(0, map.keys_len());
     ///
     /// map.insert("x-host-ip", "127.0.0.1".parse().unwrap());
-    /// map.insert_bin("x-host-name-bin", MetadataValue::from_bytes(b"localhost").unwrap());
+    /// map.insert_bin("x-host-name-bin", MetadataValue::from_bytes(b"localhost"));
     ///
     /// assert_eq!(2, map.keys_len());
     ///
@@ -417,7 +417,7 @@ impl MetadataMap {
     ///
     /// // Attempting to read a key of the wrong type fails by not
     /// // finding anything.
-    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world").unwrap());
+    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world"));
     /// assert!(map.get("host-bin").is_none());
     /// assert!(map.get("host-bin".to_string()).is_none());
     /// assert!(map.get(&("host-bin".to_string())).is_none());
@@ -443,11 +443,11 @@ impl MetadataMap {
     /// let mut map = MetadataMap::new();
     /// assert!(map.get_bin("trace-proto-bin").is_none());
     ///
-    /// map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"hello").unwrap());
+    /// map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"hello"));
     /// assert_eq!(map.get_bin("trace-proto-bin").unwrap(), &"hello");
     /// assert_eq!(map.get_bin("trace-proto-bin").unwrap(), &"hello");
     ///
-    /// map.append_bin("trace-proto-bin", MetadataValue::from_bytes(b"world").unwrap());
+    /// map.append_bin("trace-proto-bin", MetadataValue::from_bytes(b"world"));
     /// assert_eq!(map.get_bin("trace-proto-bin").unwrap(), &"hello");
     ///
     /// // Attempting to read a key of the wrong type fails by not
@@ -489,7 +489,7 @@ impl MetadataMap {
     ///
     /// // Attempting to read a key of the wrong type fails by not
     /// // finding anything.
-    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world").unwrap());
+    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world"));
     /// assert!(map.get_mut("host-bin").is_none());
     /// assert!(map.get_mut("host-bin".to_string()).is_none());
     /// assert!(map.get_mut(&("host-bin".to_string())).is_none());
@@ -513,7 +513,7 @@ impl MetadataMap {
     /// ```
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::default();
-    /// map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"hello").unwrap());
+    /// map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"hello"));
     /// map.get_bin_mut("trace-proto-bin").unwrap().set_sensitive(true);
     ///
     /// assert!(map.get_bin("trace-proto-bin").unwrap().is_sensitive());
@@ -567,7 +567,7 @@ impl MetadataMap {
     ///
     /// // Attempting to read a key of the wrong type fails by not
     /// // finding anything.
-    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world").unwrap());
+    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world"));
     /// assert!(map.get_all("host-bin").iter().next().is_none());
     /// assert!(map.get_all("host-bin".to_string()).iter().next().is_none());
     /// assert!(map.get_all(&("host-bin".to_string())).iter().next().is_none());
@@ -595,8 +595,8 @@ impl MetadataMap {
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::new();
     ///
-    /// map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"hello").unwrap());
-    /// map.append_bin("trace-proto-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
+    /// map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"hello"));
+    /// map.append_bin("trace-proto-bin", MetadataValue::from_bytes(b"goodbye"));
     ///
     /// {
     ///     let view = map.get_all_bin("trace-proto-bin");
@@ -639,7 +639,7 @@ impl MetadataMap {
     /// let mut map = MetadataMap::new();
     /// assert!(!map.contains_key("x-host"));
     ///
-    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world").unwrap());
+    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world"));
     /// map.insert("x-host", "world".parse().unwrap());
     ///
     /// // contains_key works for both Binary and Ascii keys:
@@ -727,7 +727,7 @@ impl MetadataMap {
     ///
     /// map.insert("x-word", "hello".parse().unwrap());
     /// map.append("x-word", "goodbye".parse().unwrap());
-    /// map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
+    /// map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123"));
     ///
     /// for key in map.keys() {
     ///     match key {
@@ -756,7 +756,7 @@ impl MetadataMap {
     ///
     /// map.insert("x-word", "hello".parse().unwrap());
     /// map.append("x-word", "goodbye".parse().unwrap());
-    /// map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
+    /// map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123"));
     ///
     /// for value in map.values() {
     ///     match value {
@@ -829,7 +829,7 @@ impl MetadataMap {
     ///
     /// // Attempting to read a key of the wrong type fails by not
     /// // finding anything.
-    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world").unwrap());
+    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world"));
     /// assert!(!map.entry("host-bin").is_ok());
     /// assert!(!map.entry("host-bin".to_string()).is_ok());
     /// assert!(!map.entry(&("host-bin".to_string())).is_ok());
@@ -863,8 +863,8 @@ impl MetadataMap {
     /// ];
     ///
     /// for &header in headers {
-    ///     let counter = map.entry_bin(header).unwrap().or_insert(MetadataValue::from_bytes(b"").unwrap());
-    ///     *counter = MetadataValue::from_bytes(format!("{}{}", counter.to_str().unwrap(), "1").as_bytes()).unwrap();
+    ///     let counter = map.entry_bin(header).unwrap().or_insert(MetadataValue::from_bytes(b""));
+    ///     *counter = MetadataValue::from_bytes(format!("{}{}", counter.to_str().unwrap(), "1").as_bytes());
     /// }
     ///
     /// assert_eq!(map.get_bin("content-length-bin").unwrap(), "11");
@@ -965,10 +965,10 @@ impl MetadataMap {
     /// ```
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::new();
-    /// assert!(map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"world").unwrap()).is_none());
+    /// assert!(map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"world")).is_none());
     /// assert!(!map.is_empty());
     ///
-    /// let mut prev = map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"earth").unwrap()).unwrap();
+    /// let mut prev = map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"earth")).unwrap();
     /// assert_eq!("world", prev);
     /// ```
     ///
@@ -976,14 +976,14 @@ impl MetadataMap {
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::default();
     /// // Attempting to add a binary metadata entry with an invalid name
-    /// map.insert_bin("trace-proto", MetadataValue::from_bytes(b"hello").unwrap()); // This line panics!
+    /// map.insert_bin("trace-proto", MetadataValue::from_bytes(b"hello")); // This line panics!
     /// ```
     ///
     /// ```should_panic
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::new();
     /// // Trying to insert a key that is not valid panics.
-    /// map.insert_bin("x{}host-bin", MetadataValue::from_bytes(b"world").unwrap()); // This line panics!
+    /// map.insert_bin("x{}host-bin", MetadataValue::from_bytes(b"world")); // This line panics!
     /// ```
     pub fn insert_bin<K>(&mut self, key: K, val: MetadataValue<Binary>) -> Option<MetadataValue<Binary>>
         where K: IntoMetadataKey<Binary>
@@ -1050,10 +1050,10 @@ impl MetadataMap {
     /// ```
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::new();
-    /// assert!(map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"world").unwrap()).is_none());
+    /// assert!(map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"world")).is_none());
     /// assert!(!map.is_empty());
     ///
-    /// map.append_bin("trace-proto-bin", MetadataValue::from_bytes(b"earth").unwrap());
+    /// map.append_bin("trace-proto-bin", MetadataValue::from_bytes(b"earth"));
     ///
     /// let values = map.get_all_bin("trace-proto-bin");
     /// let mut i = values.iter();
@@ -1065,14 +1065,14 @@ impl MetadataMap {
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::new();
     /// // Trying to append a key that is not valid panics.
-    /// map.append_bin("x{}host-bin", MetadataValue::from_bytes(b"world").unwrap()); // This line panics!
+    /// map.append_bin("x{}host-bin", MetadataValue::from_bytes(b"world")); // This line panics!
     /// ```
     ///
     /// ```should_panic
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::new();
     /// // Trying to append a key that is ascii panics (use append).
-    /// map.append_bin("x-host", MetadataValue::from_bytes(b"world").unwrap()); // This line panics!
+    /// map.append_bin("x-host", MetadataValue::from_bytes(b"world")); // This line panics!
     /// ```
     pub fn append_bin<K>(&mut self, key: K, value: MetadataValue<Binary>) -> bool
         where K: IntoMetadataKey<Binary>
@@ -1102,7 +1102,7 @@ impl MetadataMap {
     ///
     /// // Attempting to remove a key of the wrong type fails by not
     /// // finding anything.
-    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world").unwrap());
+    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world"));
     /// assert!(map.remove("host-bin").is_none());
     /// assert!(map.remove("host-bin".to_string()).is_none());
     /// assert!(map.remove(&("host-bin".to_string())).is_none());
@@ -1126,7 +1126,7 @@ impl MetadataMap {
     /// ```
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::new();
-    /// map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"hello.world").unwrap());
+    /// map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"hello.world"));
     ///
     /// let prev = map.remove_bin("trace-proto-bin").unwrap();
     /// assert_eq!("hello.world", prev);
@@ -2376,8 +2376,8 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
-        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye"));
+        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123"));
 
         let mut found_x_word = false;
         for key_and_value in map.iter() {
@@ -2398,7 +2398,7 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye"));
 
         let mut found_x_word_bin = false;
         for key_and_value in map.iter() {
@@ -2419,8 +2419,8 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
-        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye"));
+        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123"));
 
         let mut found_x_word = false;
         for key_and_value in map.iter_mut() {
@@ -2441,7 +2441,7 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye"));
 
         let mut found_x_word_bin = false;
         for key_and_value in map.iter_mut() {
@@ -2462,8 +2462,8 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
-        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye"));
+        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123"));
 
         let mut found_x_word = false;
         for key in map.keys() {
@@ -2484,7 +2484,7 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
+        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123"));
 
         let mut found_x_number_bin = false;
         for key in map.keys() {
@@ -2505,8 +2505,8 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
-        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye"));
+        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123"));
 
         let mut found_x_word = false;
         for value in map.values() {
@@ -2527,7 +2527,7 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye"));
 
         let mut found_x_word_bin = false;
         for value in map.values() {
@@ -2548,8 +2548,8 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
-        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye"));
+        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123"));
 
         let mut found_x_word = false;
         for value in map.values_mut() {
@@ -2570,7 +2570,7 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye"));
 
         let mut found_x_word_bin = false;
         for value in map.values_mut() {

--- a/src/metadata_map.rs
+++ b/src/metadata_map.rs
@@ -26,7 +26,7 @@ pub use self::into_metadata_key::IntoMetadataKey;
 ///
 /// map.insert("x-host", "example.com".parse().unwrap());
 /// map.insert("x-number", "123".parse().unwrap());
-/// map.insert_bin("trace-proto-bin", "[binary data]".parse().unwrap());
+/// map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"[binary data]").unwrap());
 ///
 /// assert!(map.contains_key("x-host"));
 /// assert!(!map.contains_key("x-location"));
@@ -273,7 +273,7 @@ impl MetadataMap {
     /// assert_eq!(0, map.len());
     ///
     /// map.insert("x-host-ip", "127.0.0.1".parse().unwrap());
-    /// map.insert_bin("x-host-name-bin", "localhost".parse().unwrap());
+    /// map.insert_bin("x-host-name-bin", MetadataValue::from_bytes(b"localhost").unwrap());
     ///
     /// assert_eq!(2, map.len());
     ///
@@ -299,7 +299,7 @@ impl MetadataMap {
     /// assert_eq!(0, map.keys_len());
     ///
     /// map.insert("x-host-ip", "127.0.0.1".parse().unwrap());
-    /// map.insert_bin("x-host-name-bin", "localhost".parse().unwrap());
+    /// map.insert_bin("x-host-name-bin", MetadataValue::from_bytes(b"localhost").unwrap());
     ///
     /// assert_eq!(2, map.keys_len());
     ///
@@ -417,7 +417,7 @@ impl MetadataMap {
     ///
     /// // Attempting to read a key of the wrong type fails by not
     /// // finding anything.
-    /// map.append_bin("host-bin", "world".parse().unwrap());
+    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world").unwrap());
     /// assert!(map.get("host-bin").is_none());
     /// assert!(map.get("host-bin".to_string()).is_none());
     /// assert!(map.get(&("host-bin".to_string())).is_none());
@@ -443,11 +443,11 @@ impl MetadataMap {
     /// let mut map = MetadataMap::new();
     /// assert!(map.get_bin("trace-proto-bin").is_none());
     ///
-    /// map.insert_bin("trace-proto-bin", "hello".parse().unwrap());
+    /// map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"hello").unwrap());
     /// assert_eq!(map.get_bin("trace-proto-bin").unwrap(), &"hello");
     /// assert_eq!(map.get_bin("trace-proto-bin").unwrap(), &"hello");
     ///
-    /// map.append_bin("trace-proto-bin", "world".parse().unwrap());
+    /// map.append_bin("trace-proto-bin", MetadataValue::from_bytes(b"world").unwrap());
     /// assert_eq!(map.get_bin("trace-proto-bin").unwrap(), &"hello");
     ///
     /// // Attempting to read a key of the wrong type fails by not
@@ -489,7 +489,7 @@ impl MetadataMap {
     ///
     /// // Attempting to read a key of the wrong type fails by not
     /// // finding anything.
-    /// map.append_bin("host-bin", "world".parse().unwrap());
+    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world").unwrap());
     /// assert!(map.get_mut("host-bin").is_none());
     /// assert!(map.get_mut("host-bin".to_string()).is_none());
     /// assert!(map.get_mut(&("host-bin".to_string())).is_none());
@@ -513,7 +513,7 @@ impl MetadataMap {
     /// ```
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::default();
-    /// map.insert_bin("trace-proto-bin", "hello".parse().unwrap());
+    /// map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"hello").unwrap());
     /// map.get_bin_mut("trace-proto-bin").unwrap().set_sensitive(true);
     ///
     /// assert!(map.get_bin("trace-proto-bin").unwrap().is_sensitive());
@@ -567,7 +567,7 @@ impl MetadataMap {
     ///
     /// // Attempting to read a key of the wrong type fails by not
     /// // finding anything.
-    /// map.append_bin("host-bin", "world".parse().unwrap());
+    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world").unwrap());
     /// assert!(map.get_all("host-bin").iter().next().is_none());
     /// assert!(map.get_all("host-bin".to_string()).iter().next().is_none());
     /// assert!(map.get_all(&("host-bin".to_string())).iter().next().is_none());
@@ -595,8 +595,8 @@ impl MetadataMap {
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::new();
     ///
-    /// map.insert_bin("trace-proto-bin", "hello".parse().unwrap());
-    /// map.append_bin("trace-proto-bin", "goodbye".parse().unwrap());
+    /// map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"hello").unwrap());
+    /// map.append_bin("trace-proto-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
     ///
     /// {
     ///     let view = map.get_all_bin("trace-proto-bin");
@@ -639,7 +639,7 @@ impl MetadataMap {
     /// let mut map = MetadataMap::new();
     /// assert!(!map.contains_key("x-host"));
     ///
-    /// map.append_bin("host-bin", "world".parse().unwrap());
+    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world").unwrap());
     /// map.insert("x-host", "world".parse().unwrap());
     ///
     /// // contains_key works for both Binary and Ascii keys:
@@ -727,7 +727,7 @@ impl MetadataMap {
     ///
     /// map.insert("x-word", "hello".parse().unwrap());
     /// map.append("x-word", "goodbye".parse().unwrap());
-    /// map.insert_bin("x-number-bin", "123".parse().unwrap());
+    /// map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
     ///
     /// for key in map.keys() {
     ///     match key {
@@ -756,7 +756,7 @@ impl MetadataMap {
     ///
     /// map.insert("x-word", "hello".parse().unwrap());
     /// map.append("x-word", "goodbye".parse().unwrap());
-    /// map.insert_bin("x-number-bin", "123".parse().unwrap());
+    /// map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
     ///
     /// for value in map.values() {
     ///     match value {
@@ -829,7 +829,7 @@ impl MetadataMap {
     ///
     /// // Attempting to read a key of the wrong type fails by not
     /// // finding anything.
-    /// map.append_bin("host-bin", "world".parse().unwrap());
+    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world").unwrap());
     /// assert!(!map.entry("host-bin").is_ok());
     /// assert!(!map.entry("host-bin".to_string()).is_ok());
     /// assert!(!map.entry(&("host-bin".to_string())).is_ok());
@@ -863,8 +863,8 @@ impl MetadataMap {
     /// ];
     ///
     /// for &header in headers {
-    ///     let counter = map.entry_bin(header).unwrap().or_insert("".parse().unwrap());
-    ///     *counter = format!("{}{}", counter.to_str().unwrap(), "1").parse().unwrap();
+    ///     let counter = map.entry_bin(header).unwrap().or_insert(MetadataValue::from_bytes(b"").unwrap());
+    ///     *counter = MetadataValue::from_bytes(format!("{}{}", counter.to_str().unwrap(), "1").as_bytes()).unwrap();
     /// }
     ///
     /// assert_eq!(map.get_bin("content-length-bin").unwrap(), "11");
@@ -965,10 +965,10 @@ impl MetadataMap {
     /// ```
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::new();
-    /// assert!(map.insert_bin("trace-proto-bin", "world".parse().unwrap()).is_none());
+    /// assert!(map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"world").unwrap()).is_none());
     /// assert!(!map.is_empty());
     ///
-    /// let mut prev = map.insert_bin("trace-proto-bin", "earth".parse().unwrap()).unwrap();
+    /// let mut prev = map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"earth").unwrap()).unwrap();
     /// assert_eq!("world", prev);
     /// ```
     ///
@@ -976,14 +976,14 @@ impl MetadataMap {
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::default();
     /// // Attempting to add a binary metadata entry with an invalid name
-    /// map.insert_bin("trace-proto", "hello".parse().unwrap()); // This line panics!
+    /// map.insert_bin("trace-proto", MetadataValue::from_bytes(b"hello").unwrap()); // This line panics!
     /// ```
     ///
     /// ```should_panic
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::new();
     /// // Trying to insert a key that is not valid panics.
-    /// map.insert_bin("x{}host-bin", "world".parse().unwrap()); // This line panics!
+    /// map.insert_bin("x{}host-bin", MetadataValue::from_bytes(b"world").unwrap()); // This line panics!
     /// ```
     pub fn insert_bin<K>(&mut self, key: K, val: MetadataValue<Binary>) -> Option<MetadataValue<Binary>>
         where K: IntoMetadataKey<Binary>
@@ -1050,10 +1050,10 @@ impl MetadataMap {
     /// ```
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::new();
-    /// assert!(map.insert_bin("trace-proto-bin", "world".parse().unwrap()).is_none());
+    /// assert!(map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"world").unwrap()).is_none());
     /// assert!(!map.is_empty());
     ///
-    /// map.append_bin("trace-proto-bin", "earth".parse().unwrap());
+    /// map.append_bin("trace-proto-bin", MetadataValue::from_bytes(b"earth").unwrap());
     ///
     /// let values = map.get_all_bin("trace-proto-bin");
     /// let mut i = values.iter();
@@ -1065,14 +1065,14 @@ impl MetadataMap {
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::new();
     /// // Trying to append a key that is not valid panics.
-    /// map.append_bin("x{}host-bin", "world".parse().unwrap()); // This line panics!
+    /// map.append_bin("x{}host-bin", MetadataValue::from_bytes(b"world").unwrap()); // This line panics!
     /// ```
     ///
     /// ```should_panic
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::new();
     /// // Trying to append a key that is ascii panics (use append).
-    /// map.append_bin("x-host", "world".parse().unwrap()); // This line panics!
+    /// map.append_bin("x-host", MetadataValue::from_bytes(b"world").unwrap()); // This line panics!
     /// ```
     pub fn append_bin<K>(&mut self, key: K, value: MetadataValue<Binary>) -> bool
         where K: IntoMetadataKey<Binary>
@@ -1102,7 +1102,7 @@ impl MetadataMap {
     ///
     /// // Attempting to remove a key of the wrong type fails by not
     /// // finding anything.
-    /// map.append_bin("host-bin", "world".parse().unwrap());
+    /// map.append_bin("host-bin", MetadataValue::from_bytes(b"world").unwrap());
     /// assert!(map.remove("host-bin").is_none());
     /// assert!(map.remove("host-bin".to_string()).is_none());
     /// assert!(map.remove(&("host-bin".to_string())).is_none());
@@ -1126,7 +1126,7 @@ impl MetadataMap {
     /// ```
     /// # use tower_grpc::metadata::*;
     /// let mut map = MetadataMap::new();
-    /// map.insert_bin("trace-proto-bin", "hello.world".parse().unwrap());
+    /// map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"hello.world").unwrap());
     ///
     /// let prev = map.remove_bin("trace-proto-bin").unwrap();
     /// assert_eq!("hello.world", prev);
@@ -2376,8 +2376,8 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", "goodbye".parse().unwrap());
-        map.insert_bin("x-number-bin", "123".parse().unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
+        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
 
         let mut found_x_word = false;
         for key_and_value in map.iter() {
@@ -2398,7 +2398,7 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", "goodbye".parse().unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
 
         let mut found_x_word_bin = false;
         for key_and_value in map.iter() {
@@ -2419,8 +2419,8 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", "goodbye".parse().unwrap());
-        map.insert_bin("x-number-bin", "123".parse().unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
+        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
 
         let mut found_x_word = false;
         for key_and_value in map.iter_mut() {
@@ -2441,7 +2441,7 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", "goodbye".parse().unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
 
         let mut found_x_word_bin = false;
         for key_and_value in map.iter_mut() {
@@ -2462,8 +2462,8 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", "goodbye".parse().unwrap());
-        map.insert_bin("x-number-bin", "123".parse().unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
+        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
 
         let mut found_x_word = false;
         for key in map.keys() {
@@ -2484,7 +2484,7 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.insert_bin("x-number-bin", "123".parse().unwrap());
+        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
 
         let mut found_x_number_bin = false;
         for key in map.keys() {
@@ -2505,8 +2505,8 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", "goodbye".parse().unwrap());
-        map.insert_bin("x-number-bin", "123".parse().unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
+        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
 
         let mut found_x_word = false;
         for value in map.values() {
@@ -2527,7 +2527,7 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", "goodbye".parse().unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
 
         let mut found_x_word_bin = false;
         for value in map.values() {
@@ -2548,8 +2548,8 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", "goodbye".parse().unwrap());
-        map.insert_bin("x-number-bin", "123".parse().unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
+        map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123").unwrap());
 
         let mut found_x_word = false;
         for value in map.values_mut() {
@@ -2570,7 +2570,7 @@ mod tests {
         let mut map = MetadataMap::new();
 
         map.insert("x-word", "hello".parse().unwrap());
-        map.append_bin("x-word-bin", "goodbye".parse().unwrap());
+        map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye").unwrap());
 
         let mut found_x_word_bin = false;
         for value in map.values_mut() {

--- a/src/metadata_map.rs
+++ b/src/metadata_map.rs
@@ -1,9 +1,9 @@
 use http;
+use metadata_encoding::Ascii;
+use metadata_encoding::Binary;
+use metadata_encoding::ValueEncoding;
 use metadata_key::InvalidMetadataKey;
-use metadata_key::Ascii;
-use metadata_key::Binary;
 use metadata_key::MetadataKey;
-use metadata_key::ValueEncoding;
 use metadata_value::MetadataValue;
 
 use std::marker::PhantomData;

--- a/src/metadata_map.rs
+++ b/src/metadata_map.rs
@@ -865,7 +865,7 @@ impl MetadataMap {
     ///
     /// for &header in headers {
     ///     let counter = map.entry_bin(header).unwrap().or_insert(MetadataValue::from_bytes(b""));
-    ///     *counter = MetadataValue::from_bytes(format!("{}{}", str::from_utf8(counter.as_bytes()).unwrap(), "1").as_bytes());
+    ///     *counter = MetadataValue::from_bytes(format!("{}{}", str::from_utf8(counter.to_bytes().unwrap().as_ref()).unwrap(), "1").as_bytes());
     /// }
     ///
     /// assert_eq!(map.get_bin("content-length-bin").unwrap(), "11");

--- a/src/metadata_map.rs
+++ b/src/metadata_map.rs
@@ -978,7 +978,7 @@ impl<'a, VE: ValueEncoding> Iterator for Iter<'a, VE> where VE: 'a {
             let (ref name, value) = item;
             let item : Self::Item = (
                 &name.as_str(),
-                MetadataValue::from_header_value_ref(value)
+                MetadataValue::unchecked_from_header_value_ref(value)
             );
             item
         })
@@ -1002,7 +1002,7 @@ impl<'a, VE: ValueEncoding> Iterator for IterMut<'a, VE> where VE: 'a {
             let (name, value) = item;
             let item : Self::Item = (
                 &name.as_str(),
-                MetadataValue::from_mut_header_value_ref(value)
+                MetadataValue::unchecked_from_mut_header_value_ref(value)
             );
             item
         })
@@ -1060,7 +1060,7 @@ impl<'a, VE: ValueEncoding> Iterator for Values<'a, VE> where VE: 'a {
 
     fn next(&mut self) -> Option<Self::Item> {
         // TODO(pgron): Update me, needs runtime check
-        self.inner.next().map(&MetadataValue::from_header_value_ref)
+        self.inner.next().map(&MetadataValue::unchecked_from_header_value_ref)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1074,7 +1074,7 @@ impl<'a, VE: ValueEncoding> Iterator for ValuesMut<'a, VE> where VE: 'a {
     type Item = &'a mut MetadataValue<VE>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(&MetadataValue::from_mut_header_value_ref)
+        self.inner.next().map(&MetadataValue::unchecked_from_mut_header_value_ref)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1090,7 +1090,7 @@ impl<'a, VE: ValueEncoding> Iterator for ValueIter<'a, VE> where VE: 'a {
     fn next(&mut self) -> Option<Self::Item> {
         match self.inner {
             Some(ref mut inner) =>
-                inner.next().map(&MetadataValue::from_header_value_ref),
+                inner.next().map(&MetadataValue::unchecked_from_header_value_ref),
             None => None
         }
     }
@@ -1107,7 +1107,7 @@ impl<'a, VE: ValueEncoding> DoubleEndedIterator for ValueIter<'a, VE> where VE: 
     fn next_back(&mut self) -> Option<Self::Item> {
         match self.inner {
             Some(ref mut inner) =>
-                inner.next_back().map(&MetadataValue::from_header_value_ref),
+                inner.next_back().map(&MetadataValue::unchecked_from_header_value_ref),
             None => None
         }
     }
@@ -1119,13 +1119,13 @@ impl<'a, VE: ValueEncoding> Iterator for ValueIterMut<'a, VE> where VE: 'a {
     type Item = &'a mut MetadataValue<VE>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(&MetadataValue::from_mut_header_value_ref)
+        self.inner.next().map(&MetadataValue::unchecked_from_mut_header_value_ref)
     }
 }
 
 impl<'a, VE: ValueEncoding> DoubleEndedIterator for ValueIterMut<'a, VE> where VE: 'a {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.inner.next_back().map(&MetadataValue::from_mut_header_value_ref)
+        self.inner.next_back().map(&MetadataValue::unchecked_from_mut_header_value_ref)
     }
 }
 
@@ -1286,7 +1286,7 @@ impl<'a, VE: ValueEncoding> VacantEntry<'a, VE> {
     /// assert_eq!(map.get("x-hello").unwrap(), "world");
     /// ```
     pub fn insert(self, value: MetadataValue<VE>) -> &'a mut MetadataValue<VE> {
-        MetadataValue::from_mut_header_value_ref(self.inner.insert(value.inner))
+        MetadataValue::unchecked_from_mut_header_value_ref(self.inner.insert(value.inner))
     }
 
     /// Insert the value into the entry.
@@ -1359,7 +1359,7 @@ impl<'a, VE: ValueEncoding> OccupiedEntry<'a, VE> {
     /// }
     /// ```
     pub fn get(&self) -> &MetadataValue<VE> {
-        MetadataValue::from_header_value_ref(self.inner.get())
+        MetadataValue::unchecked_from_header_value_ref(self.inner.get())
     }
 
     /// Get a mutable reference to the first value in the entry.
@@ -1384,7 +1384,7 @@ impl<'a, VE: ValueEncoding> OccupiedEntry<'a, VE> {
     /// }
     /// ```
     pub fn get_mut(&mut self) -> &mut MetadataValue<VE> {
-        MetadataValue::from_mut_header_value_ref(self.inner.get_mut())
+        MetadataValue::unchecked_from_mut_header_value_ref(self.inner.get_mut())
     }
 
     /// Converts the `OccupiedEntry` into a mutable reference to the **first**
@@ -1411,7 +1411,7 @@ impl<'a, VE: ValueEncoding> OccupiedEntry<'a, VE> {
     /// assert!(map.get("host").unwrap().is_sensitive());
     /// ```
     pub fn into_mut(self) -> &'a mut MetadataValue<VE> {
-        MetadataValue::from_mut_header_value_ref(self.inner.into_mut())
+        MetadataValue::unchecked_from_mut_header_value_ref(self.inner.into_mut())
     }
 
     /// Sets the value of the entry.
@@ -1827,14 +1827,14 @@ mod as_metadata_key {
         #[inline]
         fn get(self, map: &MetadataMap) -> Option<&MetadataValue<VE>> {
             map.headers.get(self.inner)
-                .map(&MetadataValue::from_header_value_ref)
+                .map(&MetadataValue::unchecked_from_header_value_ref)
         }
 
         #[doc(hidden)]
         #[inline]
         fn get_mut(self, map: &mut MetadataMap) -> Option<&mut MetadataValue<VE>> {
             map.headers.get_mut(self.inner)
-                .map(&MetadataValue::from_mut_header_value_ref)
+                .map(&MetadataValue::unchecked_from_mut_header_value_ref)
         }
 
         #[doc(hidden)]
@@ -1865,14 +1865,14 @@ mod as_metadata_key {
         #[inline]
         fn get(self, map: &MetadataMap) -> Option<&MetadataValue<VE>> {
             map.headers.get(&self.inner)
-                .map(&MetadataValue::from_header_value_ref)
+                .map(&MetadataValue::unchecked_from_header_value_ref)
         }
 
         #[doc(hidden)]
         #[inline]
         fn get_mut(self, map: &mut MetadataMap) -> Option<&mut MetadataValue<VE>> {
             map.headers.get_mut(&self.inner)
-                .map(&MetadataValue::from_mut_header_value_ref)
+                .map(&MetadataValue::unchecked_from_mut_header_value_ref)
         }
 
         #[doc(hidden)]
@@ -1906,7 +1906,7 @@ mod as_metadata_key {
                 return None;
             }
             map.headers.get(self)
-                .map(&MetadataValue::from_header_value_ref)
+                .map(&MetadataValue::unchecked_from_header_value_ref)
         }
 
         #[doc(hidden)]
@@ -1916,7 +1916,7 @@ mod as_metadata_key {
                 return None;
             }
             map.headers.get_mut(self)
-                .map(&MetadataValue::from_mut_header_value_ref)
+                .map(&MetadataValue::unchecked_from_mut_header_value_ref)
         }
 
         #[doc(hidden)]
@@ -1959,7 +1959,7 @@ mod as_metadata_key {
                 return None;
             }
             map.headers.get(self.as_str())
-                .map(&MetadataValue::from_header_value_ref)
+                .map(&MetadataValue::unchecked_from_header_value_ref)
         }
 
         #[doc(hidden)]
@@ -1969,7 +1969,7 @@ mod as_metadata_key {
                 return None;
             }
             map.headers.get_mut(self.as_str())
-                .map(&MetadataValue::from_mut_header_value_ref)
+                .map(&MetadataValue::unchecked_from_mut_header_value_ref)
         }
 
         #[doc(hidden)]
@@ -2012,7 +2012,7 @@ mod as_metadata_key {
                 return None;
             }
             map.headers.get(self.as_str())
-                .map(&MetadataValue::from_header_value_ref)
+                .map(&MetadataValue::unchecked_from_header_value_ref)
         }
 
         #[doc(hidden)]
@@ -2022,7 +2022,7 @@ mod as_metadata_key {
                 return None;
             }
             map.headers.get_mut(self.as_str())
-                .map(&MetadataValue::from_mut_header_value_ref)
+                .map(&MetadataValue::unchecked_from_mut_header_value_ref)
         }
 
         #[doc(hidden)]

--- a/src/metadata_map.rs
+++ b/src/metadata_map.rs
@@ -853,6 +853,7 @@ impl MetadataMap {
     ///
     /// ```
     /// # use tower_grpc::metadata::*;
+    /// # use std::str;
     /// let mut map = MetadataMap::default();
     ///
     /// let headers = &[
@@ -864,7 +865,7 @@ impl MetadataMap {
     ///
     /// for &header in headers {
     ///     let counter = map.entry_bin(header).unwrap().or_insert(MetadataValue::from_bytes(b""));
-    ///     *counter = MetadataValue::from_bytes(format!("{}{}", counter.to_str().unwrap(), "1").as_bytes());
+    ///     *counter = MetadataValue::from_bytes(format!("{}{}", str::from_utf8(counter.as_bytes()).unwrap(), "1").as_bytes());
     /// }
     ///
     /// assert_eq!(map.get_bin("content-length-bin").unwrap(), "11");

--- a/src/metadata_map.rs
+++ b/src/metadata_map.rs
@@ -135,8 +135,7 @@ pub struct ValueIterMut<'a, VE: ValueEncoding> {
     phantom: PhantomData<VE>,
 }
 
-// TODO(pgron): Document all panic-prone implicit conversions.
-// TODO(pgron): Ensure that the non-panicing string getters actually don't panic.
+// TODO(pgron): Document and test all panic-prone implicit conversions.
 
 /// A view to all values stored in a single entry.
 ///
@@ -408,6 +407,12 @@ impl MetadataMap {
     /// assert!(map.get("host-bin").is_none());
     /// assert!(map.get("host-bin".to_string()).is_none());
     /// assert!(map.get(&("host-bin".to_string())).is_none());
+    ///
+    /// // Attempting to read an invalid key string fails by not
+    /// // finding anything.
+    /// assert!(map.get("host{}bin").is_none());
+    /// assert!(map.get("host{}bin".to_string()).is_none());
+    /// assert!(map.get(&("host{}bin".to_string())).is_none());
     /// ```
     pub fn get<K>(&self, key: K) -> Option<&MetadataValue<Ascii>>
         where K: AsMetadataKey<Ascii>
@@ -437,6 +442,12 @@ impl MetadataMap {
     /// assert!(map.get_bin("host").is_none());
     /// assert!(map.get_bin("host".to_string()).is_none());
     /// assert!(map.get_bin(&("host".to_string())).is_none());
+    ///
+    /// // Attempting to read an invalid key string fails by not
+    /// // finding anything.
+    /// assert!(map.get_bin("host{}-bin").is_none());
+    /// assert!(map.get_bin("host{}-bin".to_string()).is_none());
+    /// assert!(map.get_bin(&("host{}-bin".to_string())).is_none());
     /// ```
     pub fn get_bin<K>(&self, key: K) -> Option<&MetadataValue<Binary>>
         where K: AsMetadataKey<Binary>
@@ -468,6 +479,12 @@ impl MetadataMap {
     /// assert!(map.get_mut("host-bin").is_none());
     /// assert!(map.get_mut("host-bin".to_string()).is_none());
     /// assert!(map.get_mut(&("host-bin".to_string())).is_none());
+    ///
+    /// // Attempting to read an invalid key string fails by not
+    /// // finding anything.
+    /// assert!(map.get_mut("host{}").is_none());
+    /// assert!(map.get_mut("host{}".to_string()).is_none());
+    /// assert!(map.get_mut(&("host{}".to_string())).is_none());
     /// ```
     pub fn get_mut<K>(&mut self, key: K) -> Option<&mut MetadataValue<Ascii>>
         where K: AsMetadataKey<Ascii>
@@ -493,6 +510,12 @@ impl MetadataMap {
     /// assert!(map.get_bin_mut("host").is_none());
     /// assert!(map.get_bin_mut("host".to_string()).is_none());
     /// assert!(map.get_bin_mut(&("host".to_string())).is_none());
+    ///
+    /// // Attempting to read an invalid key string fails by not
+    /// // finding anything.
+    /// assert!(map.get_bin_mut("host{}-bin").is_none());
+    /// assert!(map.get_bin_mut("host{}-bin".to_string()).is_none());
+    /// assert!(map.get_bin_mut(&("host{}-bin".to_string())).is_none());
     /// ```
     pub fn get_bin_mut<K>(&mut self, key: K) -> Option<&mut MetadataValue<Binary>>
         where K: AsMetadataKey<Binary>
@@ -534,6 +557,12 @@ impl MetadataMap {
     /// assert!(map.get_all("host-bin").iter().next().is_none());
     /// assert!(map.get_all("host-bin".to_string()).iter().next().is_none());
     /// assert!(map.get_all(&("host-bin".to_string())).iter().next().is_none());
+    ///
+    /// // Attempting to read an invalid key string fails by not
+    /// // finding anything.
+    /// assert!(map.get_all("host{}").iter().next().is_none());
+    /// assert!(map.get_all("host{}".to_string()).iter().next().is_none());
+    /// assert!(map.get_all(&("host{}".to_string())).iter().next().is_none());
     /// ```
     pub fn get_all<K>(&self, key: K) -> GetAll<Ascii>
         where K: AsMetadataKey<Ascii>
@@ -570,6 +599,12 @@ impl MetadataMap {
     /// assert!(map.get_all_bin("host").iter().next().is_none());
     /// assert!(map.get_all_bin("host".to_string()).iter().next().is_none());
     /// assert!(map.get_all_bin(&("host".to_string())).iter().next().is_none());
+    ///
+    /// // Attempting to read an invalid key string fails by not
+    /// // finding anything.
+    /// assert!(map.get_all_bin("host{}-bin").iter().next().is_none());
+    /// assert!(map.get_all_bin("host{}-bin".to_string()).iter().next().is_none());
+    /// assert!(map.get_all_bin(&("host{}-bin".to_string())).iter().next().is_none());
     /// ```
     pub fn get_all_bin<K>(&self, key: K) -> GetAll<Binary>
         where K: AsMetadataKey<Binary>
@@ -596,6 +631,9 @@ impl MetadataMap {
     /// // contains_key works for both Binary and Ascii keys:
     /// assert!(map.contains_key("x-host"));
     /// assert!(map.contains_key("host-bin"));
+    ///
+    /// // contains_key returns false for invalid keys:
+    /// assert!(!map.contains_key("x{}host"));
     /// ```
     pub fn contains_key<K>(&self, key: K) -> bool
         where K: AsEncodingAgnosticMetadataKey
@@ -777,6 +815,12 @@ impl MetadataMap {
     /// assert!(!map.entry("host-bin").is_ok());
     /// assert!(!map.entry("host-bin".to_string()).is_ok());
     /// assert!(!map.entry(&("host-bin".to_string())).is_ok());
+    ///
+    /// // Attempting to read an invalid key string fails by not
+    /// // finding anything.
+    /// assert!(!map.entry("host{}").is_ok());
+    /// assert!(!map.entry("host{}".to_string()).is_ok());
+    /// assert!(!map.entry(&("host{}".to_string())).is_ok());
     /// ```
     pub fn entry<K>(&mut self, key: K) -> Result<Entry<Ascii>, InvalidMetadataKey>
         where K: AsMetadataKey<Ascii>
@@ -814,6 +858,12 @@ impl MetadataMap {
     /// assert!(!map.entry_bin("host").is_ok());
     /// assert!(!map.entry_bin("host".to_string()).is_ok());
     /// assert!(!map.entry_bin(&("host".to_string())).is_ok());
+    ///
+    /// // Attempting to read an invalid key string fails by not
+    /// // finding anything.
+    /// assert!(!map.entry_bin("host{}-bin").is_ok());
+    /// assert!(!map.entry_bin("host{}-bin".to_string()).is_ok());
+    /// assert!(!map.entry_bin(&("host{}-bin".to_string())).is_ok());
     /// ```
     pub fn entry_bin<K>(&mut self, key: K) -> Result<Entry<Binary>, InvalidMetadataKey>
         where K: AsMetadataKey<Binary>
@@ -977,6 +1027,12 @@ impl MetadataMap {
     /// assert!(map.remove("host-bin").is_none());
     /// assert!(map.remove("host-bin".to_string()).is_none());
     /// assert!(map.remove(&("host-bin".to_string())).is_none());
+    ///
+    /// // Attempting to remove an invalid key string fails by not
+    /// // finding anything.
+    /// assert!(map.remove("host{}").is_none());
+    /// assert!(map.remove("host{}".to_string()).is_none());
+    /// assert!(map.remove(&("host{}".to_string())).is_none());
     /// ```
     pub fn remove<K>(&mut self, key: K) -> Option<MetadataValue<Ascii>>
         where K: AsMetadataKey<Ascii>
@@ -1004,6 +1060,12 @@ impl MetadataMap {
     /// assert!(map.remove_bin("host").is_none());
     /// assert!(map.remove_bin("host".to_string()).is_none());
     /// assert!(map.remove_bin(&("host".to_string())).is_none());
+    ///
+    /// // Attempting to remove an invalid key string fails by not
+    /// // finding anything.
+    /// assert!(map.remove_bin("host{}-bin").is_none());
+    /// assert!(map.remove_bin("host{}-bin".to_string()).is_none());
+    /// assert!(map.remove_bin(&("host{}-bin".to_string())).is_none());
     /// ```
     pub fn remove_bin<K>(&mut self, key: K) -> Option<MetadataValue<Binary>>
         where K: AsMetadataKey<Binary>

--- a/src/metadata_map.rs
+++ b/src/metadata_map.rs
@@ -2468,7 +2468,7 @@ mod tests {
 
         let mut found_x_word = false;
         for key in map.keys() {
-            if let KeyRef::Ascii(ref key) = key {
+            if let KeyRef::Ascii(key) = key {
                 if key.as_str() == "x-word" {
                     found_x_word = true;
                 } else {
@@ -2489,7 +2489,7 @@ mod tests {
 
         let mut found_x_number_bin = false;
         for key in map.keys() {
-            if let KeyRef::Binary(ref key) = key {
+            if let KeyRef::Binary(key) = key {
                 if key.as_str() == "x-number-bin" {
                     found_x_number_bin = true;
                 } else {
@@ -2511,7 +2511,7 @@ mod tests {
 
         let mut found_x_word = false;
         for value in map.values() {
-            if let ValueRef::Ascii(ref value) = value {
+            if let ValueRef::Ascii(value) = value {
                 if *value == "hello" {
                     found_x_word = true;
                 } else {
@@ -2531,14 +2531,10 @@ mod tests {
         map.append_bin("x-word-bin", MetadataValue::from_bytes(b"goodbye"));
 
         let mut found_x_word_bin = false;
-        for value in map.values() {
-            if let ValueRef::Binary(ref value) = value {
-                if *value == "goodbye" {
-                    found_x_word_bin = true;
-                } else {
-                    // Unexpected key
-                    assert!(false);
-                }
+        for value_ref in map.values() {
+            if let ValueRef::Binary(value) = value_ref {
+                assert_eq!(*value, "goodbye");
+                found_x_word_bin = true;
             }
         }
         assert!(found_x_word_bin);
@@ -2553,14 +2549,10 @@ mod tests {
         map.insert_bin("x-number-bin", MetadataValue::from_bytes(b"123"));
 
         let mut found_x_word = false;
-        for value in map.values_mut() {
-            if let ValueRefMut::Ascii(ref value) = value {
-                if *value == "hello" {
-                    found_x_word = true;
-                } else {
-                    // Unexpected key
-                    assert!(false);
-                }
+        for value_ref in map.values_mut() {
+            if let ValueRefMut::Ascii(value) = value_ref {
+                assert_eq!(*value, "hello");
+                found_x_word = true;
             }
         }
         assert!(found_x_word);
@@ -2575,13 +2567,9 @@ mod tests {
 
         let mut found_x_word_bin = false;
         for value in map.values_mut() {
-            if let ValueRefMut::Binary(ref value) = value {
-                if *value == "goodbye" {
-                    found_x_word_bin = true;
-                } else {
-                    // Unexpected key
-                    assert!(false);
-                }
+            if let ValueRefMut::Binary(value) = value {
+                assert_eq!(*value, "goodbye");
+                found_x_word_bin = true;
             }
         }
         assert!(found_x_word_bin);

--- a/src/metadata_value.rs
+++ b/src/metadata_value.rs
@@ -319,18 +319,16 @@ impl<VE: ValueEncoding> MetadataValue<VE> {
     /// Converts a HeaderValue reference to a MetadataValue. This method assumes
     /// that the caller has made sure that the value is of the correct Ascii or
     /// Binary value encoding.
-    // TODO(pgron): Rename to unchecked_
     #[inline]
-    pub(crate) fn from_header_value_ref(header_value: &HeaderValue) -> &Self {
+    pub(crate) fn unchecked_from_header_value_ref(header_value: &HeaderValue) -> &Self {
         unsafe { &*(header_value as *const HeaderValue as *const Self) }
     }
 
     /// Converts a HeaderValue reference to a MetadataValue. This method assumes
     /// that the caller has made sure that the value is of the correct Ascii or
     /// Binary value encoding.
-    // TODO(pgron): Rename to unchecked_
     #[inline]
-    pub(crate) fn from_mut_header_value_ref(header_value: &mut HeaderValue) -> &mut Self {
+    pub(crate) fn unchecked_from_mut_header_value_ref(header_value: &mut HeaderValue) -> &mut Self {
         unsafe { &mut *(header_value as *mut HeaderValue as *mut Self) }
     }
 }

--- a/src/metadata_value.rs
+++ b/src/metadata_value.rs
@@ -4,7 +4,10 @@ use http::header::HeaderValue;
 use std::{cmp, fmt};
 use std::error::Error;
 use std::str::FromStr;
+use std::marker::PhantomData;
 
+use metadata_encoding::Ascii;
+use metadata_encoding::Binary;
 use metadata_encoding::ValueEncoding;
 use metadata_key::MetadataKey;
 
@@ -15,10 +18,11 @@ use metadata_key::MetadataKey;
 /// [`HeaderMap`]: struct.HeaderMap.html
 #[derive(Clone, Hash)]
 #[repr(transparent)]
-pub struct MetadataValue {
+pub struct MetadataValue<VE: ValueEncoding> {
     // Note: There are unsafe transmutes that assume that the memory layout
     // of MetadataValue is identical to HeaderValue
     pub(crate) inner: HeaderValue,
+    phantom: PhantomData<VE>,
 }
 
 /// A possible error when converting a `MetadataValue` from a string or byte
@@ -42,7 +46,10 @@ pub struct ToStrError {
     _priv: (),
 }
 
-impl MetadataValue {
+pub type AsciiMetadataValue = MetadataValue<Ascii>;
+pub type BinaryMetadataValue = MetadataValue<Binary>;
+
+impl<VE: ValueEncoding> MetadataValue<VE> {
     /// Convert a static string to a `MetadataValue`.
     ///
     /// This function will not perform any copying, however the string is
@@ -58,13 +65,15 @@ impl MetadataValue {
     ///
     /// ```
     /// # use tower_grpc::metadata::*;
-    /// let val = MetadataValue::from_static("hello");
+    /// let val = AsciiMetadataValue::from_static("hello");
     /// assert_eq!(val, "hello");
     /// ```
     #[inline]
-    pub fn from_static(src: &'static str) -> MetadataValue {
+    pub fn from_static(src: &'static str) -> Self {
+        // TODO(pgron): Perform conversion
         MetadataValue {
-            inner: HeaderValue::from_static(src)
+            inner: HeaderValue::from_static(src),
+            phantom: PhantomData,
         }
     }
 
@@ -82,7 +91,7 @@ impl MetadataValue {
     ///
     /// ```
     /// # use tower_grpc::metadata::*;
-    /// let val = MetadataValue::from_str("hello").unwrap();
+    /// let val = AsciiMetadataValue::from_str("hello").unwrap();
     /// assert_eq!(val, "hello");
     /// ```
     ///
@@ -90,14 +99,16 @@ impl MetadataValue {
     ///
     /// ```
     /// # use tower_grpc::metadata::*;
-    /// let val = MetadataValue::from_str("\n");
+    /// let val = AsciiMetadataValue::from_str("\n");
     /// assert!(val.is_err());
     /// ```
     #[inline]
-    pub fn from_str(src: &str) -> Result<MetadataValue, InvalidMetadataValue> {
+    pub fn from_str(src: &str) -> Result<Self, InvalidMetadataValue> {
+        // TODO(pgron): Perform conversion
         HeaderValue::from_str(src)
             .map(|value| MetadataValue {
-                inner: value
+                inner: value,
+                phantom: PhantomData,
             })
             .map_err(|_| { InvalidMetadataValue { _priv: () } })
     }
@@ -111,11 +122,11 @@ impl MetadataValue {
     ///
     /// ```
     /// # use tower_grpc::metadata::*;
-    /// let val = MetadataValue::from_name::<Ascii>("accept".parse().unwrap());
-    /// assert_eq!(val, MetadataValue::from_bytes(b"accept").unwrap());
+    /// let val = AsciiMetadataValue::from_name::<Ascii>("accept".parse().unwrap());
+    /// assert_eq!(val, AsciiMetadataValue::from_bytes(b"accept").unwrap());
     /// ```
     #[inline]
-    pub fn from_name<VE: ValueEncoding>(name: MetadataKey<VE>) -> MetadataValue {
+    pub fn from_name<KeyVE: ValueEncoding>(name: MetadataKey<KeyVE>) -> Self {
         name.into()
     }
 
@@ -132,7 +143,7 @@ impl MetadataValue {
     ///
     /// ```
     /// # use tower_grpc::metadata::*;
-    /// let val = MetadataValue::from_bytes(b"hello\xfa").unwrap();
+    /// let val = AsciiMetadataValue::from_bytes(b"hello\xfa").unwrap();
     /// assert_eq!(val, &b"hello\xfa"[..]);
     /// ```
     ///
@@ -140,14 +151,16 @@ impl MetadataValue {
     ///
     /// ```
     /// # use tower_grpc::metadata::*;
-    /// let val = MetadataValue::from_bytes(b"\n");
+    /// let val = AsciiMetadataValue::from_bytes(b"\n");
     /// assert!(val.is_err());
     /// ```
     #[inline]
-    pub fn from_bytes(src: &[u8]) -> Result<MetadataValue, InvalidMetadataValue> {
+    pub fn from_bytes(src: &[u8]) -> Result<Self, InvalidMetadataValue> {
+        // TODO(pgron): Perform conversion
         HeaderValue::from_bytes(src)
             .map(|value| MetadataValue {
-                inner: value
+                inner: value,
+                phantom: PhantomData,
             })
             .map_err(|_| { InvalidMetadataValue { _priv: () } })
     }
@@ -161,10 +174,12 @@ impl MetadataValue {
     /// This function is intended to be replaced in the future by a `TryFrom`
     /// implementation once the trait is stabilized in std.
     #[inline]
-    pub fn from_shared(src: Bytes) -> Result<MetadataValue, InvalidMetadataValueBytes> {
+    pub fn from_shared(src: Bytes) -> Result<Self, InvalidMetadataValueBytes> {
+        // TODO(pgron): Perform conversion
         HeaderValue::from_shared(src)
             .map(|value| MetadataValue {
-                inner: value
+                inner: value,
+                phantom: PhantomData,
             })
             .map_err(|_| {
                 InvalidMetadataValueBytes(InvalidMetadataValue { _priv: () })
@@ -176,9 +191,11 @@ impl MetadataValue {
     /// This function does NOT validate that illegal bytes are not contained
     /// within the buffer.
     #[inline]
-    pub unsafe fn from_shared_unchecked(src: Bytes) -> MetadataValue {
+    pub unsafe fn from_shared_unchecked(src: Bytes) -> Self {
+        // TODO(pgron): Perform conversion
         MetadataValue {
-            inner: HeaderValue::from_shared_unchecked(src)
+            inner: HeaderValue::from_shared_unchecked(src),
+            phantom: PhantomData,
         }
     }
 
@@ -192,7 +209,7 @@ impl MetadataValue {
     ///
     /// ```
     /// # use tower_grpc::metadata::*;
-    /// let val = MetadataValue::from_static("hello");
+    /// let val = AsciiMetadataValue::from_static("hello");
     /// assert_eq!(val.to_str().unwrap(), "hello");
     /// ```
     pub fn to_str(&self) -> Result<&str, ToStrError> {
@@ -207,7 +224,7 @@ impl MetadataValue {
     ///
     /// ```
     /// # use tower_grpc::metadata::*;
-    /// let val = MetadataValue::from_static("hello");
+    /// let val = AsciiMetadataValue::from_static("hello");
     /// assert_eq!(val.len(), 5);
     /// ```
     #[inline]
@@ -221,10 +238,10 @@ impl MetadataValue {
     ///
     /// ```
     /// # use tower_grpc::metadata::*;
-    /// let val = MetadataValue::from_static("");
+    /// let val = AsciiMetadataValue::from_static("");
     /// assert!(val.is_empty());
     ///
-    /// let val = MetadataValue::from_static("hello");
+    /// let val = AsciiMetadataValue::from_static("hello");
     /// assert!(!val.is_empty());
     /// ```
     #[inline]
@@ -238,7 +255,7 @@ impl MetadataValue {
     ///
     /// ```
     /// # use tower_grpc::metadata::*;
-    /// let val = MetadataValue::from_static("hello");
+    /// let val = AsciiMetadataValue::from_static("hello");
     /// assert_eq!(val.as_bytes(), b"hello");
     /// ```
     #[inline]
@@ -252,7 +269,7 @@ impl MetadataValue {
     ///
     /// ```
     /// # use tower_grpc::metadata::*;
-    /// let mut val = MetadataValue::from_static("my secret");
+    /// let mut val = AsciiMetadataValue::from_static("my secret");
     ///
     /// val.set_sensitive(true);
     /// assert!(val.is_sensitive());
@@ -278,7 +295,7 @@ impl MetadataValue {
     ///
     /// ```
     /// # use tower_grpc::metadata::*;
-    /// let mut val = MetadataValue::from_static("my secret");
+    /// let mut val = AsciiMetadataValue::from_static("my secret");
     ///
     /// val.set_sensitive(true);
     /// assert!(val.is_sensitive());
@@ -291,45 +308,66 @@ impl MetadataValue {
         self.inner.is_sensitive()
     }
 
+    /// Converts a HeaderValue to a MetadataValue. This method assumes that the
+    /// caller has made sure that the value is of the correct Ascii or Binary
+    /// value encoding.
     #[inline]
-    pub(crate) fn from_header_value(header_value: &HeaderValue) -> &Self {
+    pub(crate) fn unchecked_from_header_value(value: HeaderValue) -> Self {
+        MetadataValue { inner: value, phantom: PhantomData }
+    }
+
+    /// Converts a HeaderValue reference to a MetadataValue. This method assumes
+    /// that the caller has made sure that the value is of the correct Ascii or
+    /// Binary value encoding.
+    // TODO(pgron): Rename to unchecked_
+    #[inline]
+    pub(crate) fn from_header_value_ref(header_value: &HeaderValue) -> &Self {
         unsafe { &*(header_value as *const HeaderValue as *const Self) }
     }
 
+    /// Converts a HeaderValue reference to a MetadataValue. This method assumes
+    /// that the caller has made sure that the value is of the correct Ascii or
+    /// Binary value encoding.
+    // TODO(pgron): Rename to unchecked_
     #[inline]
-    pub(crate) fn from_mut_header_value(header_value: &mut HeaderValue) -> &mut Self {
+    pub(crate) fn from_mut_header_value_ref(header_value: &mut HeaderValue) -> &mut Self {
         unsafe { &mut *(header_value as *mut HeaderValue as *mut Self) }
     }
 }
 
-impl AsRef<[u8]> for MetadataValue {
+impl<VE: ValueEncoding> AsRef<[u8]> for MetadataValue<VE> {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.inner.as_ref()
     }
 }
 
-impl fmt::Debug for MetadataValue {
+impl<VE: ValueEncoding> fmt::Debug for MetadataValue<VE> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.inner.fmt(f)
     }
 }
 
-impl<VE: ValueEncoding> From<MetadataKey<VE>> for MetadataValue {
+impl<KeyVE: ValueEncoding, ValueVE: ValueEncoding>
+From<MetadataKey<KeyVE>> for MetadataValue<ValueVE> {
     #[inline]
-    fn from(h: MetadataKey<VE>) -> MetadataValue {
+    fn from(h: MetadataKey<KeyVE>) -> MetadataValue<ValueVE> {
+        // TODO(pgron): Perform conversion
         MetadataValue {
-            inner: h.inner.into()
+            inner: h.inner.into(),
+            phantom: PhantomData,
         }
     }
 }
 
 macro_rules! from_integers {
     ($($name:ident: $t:ident => $max_len:expr),*) => {$(
-        impl From<$t> for MetadataValue {
-            fn from(num: $t) -> MetadataValue {
+        impl<VE: ValueEncoding> From<$t> for MetadataValue<VE> {
+            fn from(num: $t) -> MetadataValue<VE> {
+                // TODO(pgron): Perform conversion
                 MetadataValue {
-                    inner: HeaderValue::from(num)
+                    inner: HeaderValue::from(num),
+                    phantom: PhantomData,
                 }
             }
         }
@@ -337,11 +375,11 @@ macro_rules! from_integers {
         #[test]
         fn $name() {
             let n: $t = 55;
-            let val = MetadataValue::from(n);
+            let val = AsciiMetadataValue::from(n);
             assert_eq!(val, &n.to_string());
 
             let n = ::std::$t::MAX;
-            let val = MetadataValue::from(n);
+            let val = AsciiMetadataValue::from(n);
             assert_eq!(val, &n.to_string());
         }
     )*};
@@ -350,7 +388,7 @@ macro_rules! from_integers {
 from_integers! {
     // integer type => maximum decimal length
 
-    // u8 purposely left off... MetadataValue::from(b'3') could be confusing
+    // u8 purposely left off... AsciiMetadataValue::from(b'3') could be confusing
     from_u16: u16 => 5,
     from_i16: i16 => 6,
     from_u32: u32 => 10,
@@ -390,31 +428,31 @@ mod from_metadata_name_tests {
 
         assert_eq!(
             map.get("accept").unwrap(),
-            MetadataValue::from_bytes(b"hello-world").unwrap()
+            AsciiMetadataValue::from_bytes(b"hello-world").unwrap()
         );
         */
     }
 }
 
-impl FromStr for MetadataValue {
+impl<VE: ValueEncoding> FromStr for MetadataValue<VE> {
     type Err = InvalidMetadataValue;
 
     #[inline]
-    fn from_str(s: &str) -> Result<MetadataValue, Self::Err> {
-        MetadataValue::from_str(s)
+    fn from_str(s: &str) -> Result<MetadataValue<VE>, Self::Err> {
+        MetadataValue::<VE>::from_str(s)
     }
 }
 
-impl From<MetadataValue> for Bytes {
+impl<VE: ValueEncoding> From<MetadataValue<VE>> for Bytes {
     #[inline]
-    fn from(value: MetadataValue) -> Bytes {
+    fn from(value: MetadataValue<VE>) -> Bytes {
         Bytes::from(value.inner)
     }
 }
 
-impl<'a> From<&'a MetadataValue> for MetadataValue {
+impl<'a, VE: ValueEncoding> From<&'a MetadataValue<VE>> for MetadataValue<VE> {
     #[inline]
-    fn from(t: &'a MetadataValue) -> Self {
+    fn from(t: &'a MetadataValue<VE>) -> Self {
         t.clone()
     }
 }
@@ -457,129 +495,129 @@ impl Error for ToStrError {
 
 // ===== PartialEq / PartialOrd =====
 
-impl PartialEq for MetadataValue {
+impl<VE: ValueEncoding> PartialEq for MetadataValue<VE> {
     #[inline]
-    fn eq(&self, other: &MetadataValue) -> bool {
+    fn eq(&self, other: &MetadataValue<VE>) -> bool {
         self.inner == other.inner
     }
 }
 
-impl Eq for MetadataValue {}
+impl<VE: ValueEncoding> Eq for MetadataValue<VE> {}
 
-impl PartialOrd for MetadataValue {
+impl<VE: ValueEncoding> PartialOrd for MetadataValue<VE> {
     #[inline]
-    fn partial_cmp(&self, other: &MetadataValue) -> Option<cmp::Ordering> {
+    fn partial_cmp(&self, other: &MetadataValue<VE>) -> Option<cmp::Ordering> {
         self.inner.partial_cmp(&other.inner)
     }
 }
 
-impl Ord for MetadataValue {
+impl<VE: ValueEncoding> Ord for MetadataValue<VE> {
     #[inline]
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         self.inner.cmp(&other.inner)
     }
 }
 
-impl PartialEq<str> for MetadataValue {
+impl<VE: ValueEncoding> PartialEq<str> for MetadataValue<VE> {
     #[inline]
     fn eq(&self, other: &str) -> bool {
         self.inner == other.as_bytes()
     }
 }
 
-impl PartialEq<[u8]> for MetadataValue {
+impl<VE: ValueEncoding> PartialEq<[u8]> for MetadataValue<VE> {
     #[inline]
     fn eq(&self, other: &[u8]) -> bool {
         self.inner == other
     }
 }
 
-impl PartialOrd<str> for MetadataValue {
+impl<VE: ValueEncoding> PartialOrd<str> for MetadataValue<VE> {
     #[inline]
     fn partial_cmp(&self, other: &str) -> Option<cmp::Ordering> {
         self.inner.partial_cmp(other.as_bytes())
     }
 }
 
-impl PartialOrd<[u8]> for MetadataValue {
+impl<VE: ValueEncoding> PartialOrd<[u8]> for MetadataValue<VE> {
     #[inline]
     fn partial_cmp(&self, other: &[u8]) -> Option<cmp::Ordering> {
         self.inner.partial_cmp(other)
     }
 }
 
-impl PartialEq<MetadataValue> for str {
+impl<VE: ValueEncoding> PartialEq<MetadataValue<VE>> for str {
     #[inline]
-    fn eq(&self, other: &MetadataValue) -> bool {
+    fn eq(&self, other: &MetadataValue<VE>) -> bool {
         *other == *self
     }
 }
 
-impl PartialEq<MetadataValue> for [u8] {
+impl<VE: ValueEncoding> PartialEq<MetadataValue<VE>> for [u8] {
     #[inline]
-    fn eq(&self, other: &MetadataValue) -> bool {
+    fn eq(&self, other: &MetadataValue<VE>) -> bool {
         *other == *self
     }
 }
 
-impl PartialOrd<MetadataValue> for str {
+impl<VE: ValueEncoding> PartialOrd<MetadataValue<VE>> for str {
     #[inline]
-    fn partial_cmp(&self, other: &MetadataValue) -> Option<cmp::Ordering> {
+    fn partial_cmp(&self, other: &MetadataValue<VE>) -> Option<cmp::Ordering> {
         self.as_bytes().partial_cmp(other.as_bytes())
     }
 }
 
-impl PartialOrd<MetadataValue> for [u8] {
+impl<VE: ValueEncoding> PartialOrd<MetadataValue<VE>> for [u8] {
     #[inline]
-    fn partial_cmp(&self, other: &MetadataValue) -> Option<cmp::Ordering> {
+    fn partial_cmp(&self, other: &MetadataValue<VE>) -> Option<cmp::Ordering> {
         self.partial_cmp(other.as_bytes())
     }
 }
 
-impl PartialEq<String> for MetadataValue {
+impl<VE: ValueEncoding> PartialEq<String> for MetadataValue<VE> {
     #[inline]
     fn eq(&self, other: &String) -> bool {
         *self == &other[..]
     }
 }
 
-impl PartialOrd<String> for MetadataValue {
+impl<VE: ValueEncoding> PartialOrd<String> for MetadataValue<VE> {
     #[inline]
     fn partial_cmp(&self, other: &String) -> Option<cmp::Ordering> {
         self.inner.partial_cmp(other.as_bytes())
     }
 }
 
-impl PartialEq<MetadataValue> for String {
+impl<VE: ValueEncoding> PartialEq<MetadataValue<VE>> for String {
     #[inline]
-    fn eq(&self, other: &MetadataValue) -> bool {
+    fn eq(&self, other: &MetadataValue<VE>) -> bool {
         *other == *self
     }
 }
 
-impl PartialOrd<MetadataValue> for String {
+impl<VE: ValueEncoding> PartialOrd<MetadataValue<VE>> for String {
     #[inline]
-    fn partial_cmp(&self, other: &MetadataValue) -> Option<cmp::Ordering> {
+    fn partial_cmp(&self, other: &MetadataValue<VE>) -> Option<cmp::Ordering> {
         self.as_bytes().partial_cmp(other.as_bytes())
     }
 }
 
-impl<'a> PartialEq<MetadataValue> for &'a MetadataValue {
+impl<'a, VE: ValueEncoding> PartialEq<MetadataValue<VE>> for &'a MetadataValue<VE> {
     #[inline]
-    fn eq(&self, other: &MetadataValue) -> bool {
+    fn eq(&self, other: &MetadataValue<VE>) -> bool {
         **self == *other
     }
 }
 
-impl<'a> PartialOrd<MetadataValue> for &'a MetadataValue {
+impl<'a, VE: ValueEncoding> PartialOrd<MetadataValue<VE>> for &'a MetadataValue<VE> {
     #[inline]
-    fn partial_cmp(&self, other: &MetadataValue) -> Option<cmp::Ordering> {
+    fn partial_cmp(&self, other: &MetadataValue<VE>) -> Option<cmp::Ordering> {
         (**self).partial_cmp(other)
     }
 }
 
-impl<'a, T: ?Sized> PartialEq<&'a T> for MetadataValue
-    where MetadataValue: PartialEq<T>
+impl<'a, VE: ValueEncoding, T: ?Sized> PartialEq<&'a T> for MetadataValue<VE>
+    where MetadataValue<VE>: PartialEq<T>
 {
     #[inline]
     fn eq(&self, other: &&'a T) -> bool {
@@ -587,8 +625,8 @@ impl<'a, T: ?Sized> PartialEq<&'a T> for MetadataValue
     }
 }
 
-impl<'a, T: ?Sized> PartialOrd<&'a T> for MetadataValue
-    where MetadataValue: PartialOrd<T>
+impl<'a, VE: ValueEncoding, T: ?Sized> PartialOrd<&'a T> for MetadataValue<VE>
+    where MetadataValue<VE>: PartialOrd<T>
 {
     #[inline]
     fn partial_cmp(&self, other: &&'a T) -> Option<cmp::Ordering> {
@@ -596,16 +634,16 @@ impl<'a, T: ?Sized> PartialOrd<&'a T> for MetadataValue
     }
 }
 
-impl<'a> PartialEq<MetadataValue> for &'a str {
+impl<'a, VE: ValueEncoding> PartialEq<MetadataValue<VE>> for &'a str {
     #[inline]
-    fn eq(&self, other: &MetadataValue) -> bool {
+    fn eq(&self, other: &MetadataValue<VE>) -> bool {
         *other == *self
     }
 }
 
-impl<'a> PartialOrd<MetadataValue> for &'a str {
+impl<'a, VE: ValueEncoding> PartialOrd<MetadataValue<VE>> for &'a str {
     #[inline]
-    fn partial_cmp(&self, other: &MetadataValue) -> Option<cmp::Ordering> {
+    fn partial_cmp(&self, other: &MetadataValue<VE>) -> Option<cmp::Ordering> {
         self.as_bytes().partial_cmp(other.as_bytes())
     }
 }
@@ -619,12 +657,12 @@ fn test_debug() {
     ];
 
     for &(value, expected) in cases {
-        let val = MetadataValue::from_bytes(value.as_bytes()).unwrap();
+        let val = AsciiMetadataValue::from_bytes(value.as_bytes()).unwrap();
         let actual = format!("{:?}", val);
         assert_eq!(expected, actual);
     }
 
-    let mut sensitive = MetadataValue::from_static("password");
+    let mut sensitive = AsciiMetadataValue::from_static("password");
     sensitive.set_sensitive(true);
     assert_eq!("Sensitive", format!("{:?}", sensitive));
 }

--- a/src/metadata_value.rs
+++ b/src/metadata_value.rs
@@ -6,6 +6,7 @@ use std::error::Error;
 use std::str::FromStr;
 
 use metadata_key::MetadataKey;
+use metadata_key::ValueEncoding;
 
 /// Represents a custom metadata field value.
 ///
@@ -110,11 +111,11 @@ impl MetadataValue {
     ///
     /// ```
     /// # use tower_grpc::metadata::*;
-    /// let val = MetadataValue::from_name("accept".parse().unwrap());
+    /// let val = MetadataValue::from_name::<Ascii>("accept".parse().unwrap());
     /// assert_eq!(val, MetadataValue::from_bytes(b"accept").unwrap());
     /// ```
     #[inline]
-    pub fn from_name(name: MetadataKey) -> MetadataValue {
+    pub fn from_name<VE: ValueEncoding>(name: MetadataKey<VE>) -> MetadataValue {
         name.into()
     }
 
@@ -314,9 +315,9 @@ impl fmt::Debug for MetadataValue {
     }
 }
 
-impl From<MetadataKey> for MetadataValue {
+impl<VE: ValueEncoding> From<MetadataKey<VE>> for MetadataValue {
     #[inline]
-    fn from(h: MetadataKey) -> MetadataValue {
+    fn from(h: MetadataKey<VE>) -> MetadataValue {
         MetadataValue {
             inner: h.inner.into()
         }

--- a/src/metadata_value.rs
+++ b/src/metadata_value.rs
@@ -423,20 +423,18 @@ from_integers! {
 
 #[cfg(test)]
 mod from_metadata_name_tests {
-    //use super::*;
+    use super::*;
     use metadata_map::MetadataMap;
 
     #[test]
     fn it_can_insert_metadata_key_as_metadata_value() {
-        let mut _map = MetadataMap::new();
-/* TODO(pgron): Add me back
-        map.insert("accept", MetadataKey::from_bytes(b"hello-world").unwrap().into());
+        let mut map = MetadataMap::new();
+        map.insert("accept", MetadataKey::<Ascii>::from_bytes(b"hello-world").unwrap().into());
 
         assert_eq!(
             map.get("accept").unwrap(),
             AsciiMetadataValue::from_bytes(b"hello-world").unwrap()
         );
-        */
     }
 }
 

--- a/src/metadata_value.rs
+++ b/src/metadata_value.rs
@@ -699,3 +699,22 @@ fn test_debug() {
     sensitive.set_sensitive(true);
     assert_eq!("Sensitive", format!("{:?}", sensitive));
 }
+
+
+#[test]
+fn test_is_empty() {
+    fn from_str<VE: ValueEncoding>(s: &str) -> MetadataValue<VE> {
+        MetadataValue::<VE>::unchecked_from_header_value(s.parse().unwrap())
+    }
+
+    assert!(from_str::<Ascii>("").is_empty());
+    assert!(from_str::<Binary>("").is_empty());
+    assert!(!from_str::<Ascii>("a").is_empty());
+    assert!(!from_str::<Binary>("a").is_empty());
+    assert!(!from_str::<Ascii>("=").is_empty());
+    assert!(from_str::<Binary>("=").is_empty());
+    assert!(!from_str::<Ascii>("===").is_empty());
+    assert!(from_str::<Binary>("===").is_empty());
+    assert!(!from_str::<Ascii>("=====").is_empty());
+    assert!(from_str::<Binary>("=====").is_empty());
+}

--- a/src/metadata_value.rs
+++ b/src/metadata_value.rs
@@ -31,7 +31,7 @@ pub struct MetadataValue<VE: ValueEncoding> {
 ///
 /// Metadata field values may contain opaque bytes, in which case it is not
 /// possible to represent the value as a string.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ToStrError {
     _priv: (),
 }
@@ -75,24 +75,6 @@ impl<VE: ValueEncoding> MetadataValue<VE> {
             inner: HeaderValue::from_shared_unchecked(src),
             phantom: PhantomData,
         }
-    }
-
-    /// Yields a `&str` slice if the `MetadataValue` only contains visible ASCII
-    /// chars.
-    ///
-    /// This function will perform a scan of the metadata value, checking all the
-    /// characters.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use tower_grpc::metadata::*;
-    /// let val = AsciiMetadataValue::from_static("hello");
-    /// assert_eq!(val.to_str().unwrap(), "hello");
-    /// ```
-    pub fn to_str(&self) -> Result<&str, ToStrError> {
-        // TODO(pgron): Perform conversion here
-        return self.inner.to_str().map_err(|_| { ToStrError { _priv: () } })
     }
 
     /// Returns true if the `MetadataValue` has a length of zero bytes.
@@ -331,6 +313,23 @@ impl MetadataValue<Ascii> {
     pub fn len(&self) -> usize {
         self.inner.len()
     }
+
+    /// Yields a `&str` slice if the `MetadataValue` only contains visible ASCII
+    /// chars.
+    ///
+    /// This function will perform a scan of the metadata value, checking all the
+    /// characters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let val = AsciiMetadataValue::from_static("hello");
+    /// assert_eq!(val.to_str().unwrap(), "hello");
+    /// ```
+    pub fn to_str(&self) -> Result<&str, ToStrError> {
+        return self.inner.to_str().map_err(|_| { ToStrError::new() })
+    }
 }
 
 impl MetadataValue<Binary> {
@@ -471,6 +470,14 @@ impl<'a, VE: ValueEncoding> From<&'a MetadataValue<VE>> for MetadataValue<VE> {
     #[inline]
     fn from(t: &'a MetadataValue<VE>) -> Self {
         t.clone()
+    }
+}
+
+// ===== ToStrError =====
+
+impl ToStrError {
+    pub fn new() -> Self {
+        Default::default()
     }
 }
 

--- a/src/metadata_value.rs
+++ b/src/metadata_value.rs
@@ -5,8 +5,8 @@ use std::{cmp, fmt};
 use std::error::Error;
 use std::str::FromStr;
 
+use metadata_encoding::ValueEncoding;
 use metadata_key::MetadataKey;
-use metadata_key::ValueEncoding;
 
 /// Represents a custom metadata field value.
 ///

--- a/src/metadata_value.rs
+++ b/src/metadata_value.rs
@@ -368,9 +368,8 @@ From<MetadataKey<KeyVE>> for MetadataValue<Ascii> {
 
 macro_rules! from_integers {
     ($($name:ident: $t:ident => $max_len:expr),*) => {$(
-        impl<VE: ValueEncoding> From<$t> for MetadataValue<VE> {
-            fn from(num: $t) -> MetadataValue<VE> {
-                // TODO(pgron): Perform conversion
+        impl From<$t> for MetadataValue<Ascii> {
+            fn from(num: $t) -> MetadataValue<Ascii> {
                 MetadataValue {
                     inner: HeaderValue::from(num),
                     phantom: PhantomData,

--- a/src/metadata_value.rs
+++ b/src/metadata_value.rs
@@ -155,6 +155,22 @@ impl<VE: ValueEncoding> MetadataValue<VE> {
         self.inner.is_sensitive()
     }
 
+    /// Converts a `MetadataValue` to a byte slice. For Binary values, the
+    /// return value is base64 encoded.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tower_grpc::metadata::*;
+    /// let val = AsciiMetadataValue::from_static("hello");
+    // TODO(pgron): Add binary example
+    /// assert_eq!(val.as_encoded_bytes(), b"hello");
+    /// ```
+    #[inline]
+    pub fn as_encoded_bytes(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+
     /// Converts a HeaderValue to a MetadataValue. This method assumes that the
     /// caller has made sure that the value is of the correct Ascii or Binary
     /// value encoding.

--- a/src/metadata_value.rs
+++ b/src/metadata_value.rs
@@ -355,11 +355,10 @@ impl<VE: ValueEncoding> fmt::Debug for MetadataValue<VE> {
     }
 }
 
-impl<KeyVE: ValueEncoding, ValueVE: ValueEncoding>
-From<MetadataKey<KeyVE>> for MetadataValue<ValueVE> {
+impl<KeyVE: ValueEncoding>
+From<MetadataKey<KeyVE>> for MetadataValue<Ascii> {
     #[inline]
-    fn from(h: MetadataKey<KeyVE>) -> MetadataValue<ValueVE> {
-        // TODO(pgron): Perform conversion
+    fn from(h: MetadataKey<KeyVE>) -> MetadataValue<Ascii> {
         MetadataValue {
             inner: h.inner.into(),
             phantom: PhantomData,

--- a/src/metadata_value.rs
+++ b/src/metadata_value.rs
@@ -314,12 +314,12 @@ impl MetadataValue<Ascii> {
     ///
     /// ```
     /// # use tower_grpc::metadata::*;
-    /// let val = AsciiMetadataValue::from_name::<Ascii>("accept".parse().unwrap());
+    /// let val = AsciiMetadataValue::from_key::<Ascii>("accept".parse().unwrap());
     /// assert_eq!(val, AsciiMetadataValue::from_bytes(b"accept").unwrap());
     /// ```
     #[inline]
-    pub fn from_name<KeyVE: ValueEncoding>(name: MetadataKey<KeyVE>) -> Self {
-        name.into()
+    pub fn from_key<KeyVE: ValueEncoding>(key: MetadataKey<KeyVE>) -> Self {
+        key.into()
     }
 
     /// Returns the length of `self`, in bytes.


### PR DESCRIPTION
Adds support for base64 encoded "-bin" gRPC custom metadata.

Fixes #79.

Necessary for #27. See discussion at #90. This is a follow-up of #92.

Things to look for when reviewing:

* How do you like what the user-facing API ends up like?
* The `ValueEncoding` trait is afaik not importable from outside of this crate. Is that enough to prevent others from making implementations of it? It's not supposed to be possible.

Ping @carllerche here is a more or less fully fleshed out PR of what we discussed before.
