### PR TITLE
Some status code improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ futures = "0.1"
 http = "0.1"
 h2 = "0.1.11"
 log = "0.4"
+percent-encoding = "1.0.1"
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2", optional = true }
 tower-http = { git = "https://github.com/tower-rs/tower-http" }
 tower-service = { git = "https://github.com/tower-rs/tower"  }

--- a/src/client/client_streaming.rs
+++ b/src/client/client_streaming.rs
@@ -52,7 +52,7 @@ where T: Message + Default,
                             ::Error::Protocol(p) => ::Error::Protocol(p),
                             ::Error::Inner(()) => ::Error::Protocol(ProtocolError::Internal),
                             ::Error::Decode(e) => ::Error::Decode(e),
-                            ::Error::Grpc(s, h) => ::Error::Grpc(s, h),
+                            ::Error::Grpc(s) => ::Error::Grpc(s),
                         });
 
                     let message = match try_ready!(res) {

--- a/src/client/streaming.rs
+++ b/src/client/streaming.rs
@@ -53,7 +53,7 @@ where T: Message + Default,
         let expect_additional_trailers = trailers_only_status.is_none();
         if let Some(status) = trailers_only_status {
             if status.code() != Code::Ok {
-                return Err(::Error::Grpc(status, head.headers));
+                return Err(::Error::Grpc(status));
             }
         }
 

--- a/src/generic/server/streaming.rs
+++ b/src/generic/server/streaming.rs
@@ -43,7 +43,7 @@ where T: Future<Item = Response<S>,
             Ok(Async::NotReady) => return Ok(Async::NotReady),
             Err(e) => {
                 match e {
-                    ::Error::Grpc(status, _headers) => {
+                    ::Error::Grpc(status) => {
                         let response = Response::new(Encode::error(status));
                         return Ok(response.into_http().into());
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate http;
 extern crate h2;
 #[macro_use]
 extern crate log;
+extern crate percent_encoding;
 extern crate tower_http;
 extern crate tower_service;
 extern crate tower_util;

--- a/src/status.rs
+++ b/src/status.rs
@@ -28,7 +28,7 @@ impl Status {
     pub fn from_header_map(header_map: &HeaderMap) -> Option<Status> {
         header_map.get(GRPC_STATUS_HEADER_CODE).clone().map(|code| {
             let code = ::Code::from_bytes(code.as_ref());
-            let error_message = header_map.get(GRPC_STATUS_HEADER_CODE)
+            let error_message = header_map.get(GRPC_STATUS_MESSAGE_HEADER)
                 .map(|header| header.to_str().map(|header| header.to_owned()))
                 .unwrap_or_else(|| Ok(String::new()));
             let binary_error_details = header_map.get(GRPC_STATUS_DETAILS_HEADER)
@@ -226,7 +226,7 @@ pub fn infer_grpc_status(trailers: Option<HeaderMap>, status_code: http::StatusC
             if status.code() == ::Code::Ok {
                 return Ok(());
             } else {
-                return Err(::Error::Grpc(status, trailers));
+                return Err(::Error::Grpc(status));
             }
         }
     }
@@ -244,6 +244,5 @@ pub fn infer_grpc_status(trailers: Option<HeaderMap>, status_code: http::StatusC
         _ => Code::Unknown,
     };
     let status = Status::with_code(code);
-    let header_map = status.to_header_map().unwrap();
-    Err(::Error::Grpc(status, header_map))
+    Err(::Error::Grpc(status))
 }

--- a/tower-grpc-interop/README.md
+++ b/tower-grpc-interop/README.md
@@ -23,7 +23,7 @@ Note that currently, only the interop test client is implemented. The `docker-co
 - [ ] ~`per_rpc_creds`~ requires auth, NYI
 - [ ] `custom_metadata`
 - [x] `status_code_and_message`
-- [ ] `special_status_message`
+- [x] `special_status_message`
 - [x] `unimplemented_method`
 - [x] `unimplemented_service`
 - [ ] `cancel_after_begin`

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -547,7 +547,7 @@ impl TestClients {
                 test_assert!(
                     "call must fail with unknown status code",
                     match &result {
-                        Err(Grpc(status, _)) =>
+                        Err(Grpc(status)) =>
                             status.code() == tower_grpc::Code::Unknown,
                         _ => false,
                     },
@@ -556,8 +556,8 @@ impl TestClients {
                 test_assert!(
                     "call must repsond with expected status message",
                     match &result {
-                        Err(Grpc(_, header_map)) =>
-                            header_map["grpc-message"] == TEST_STATUS_MESSAGE,
+                        Err(Grpc(status)) =>
+                            status.error_message() == TEST_STATUS_MESSAGE,
                         _ => false,
                     },
                     format!("result={:?}", result)
@@ -606,7 +606,7 @@ impl TestClients {
                 let assertions = vec![test_assert!(
                     "call must fail with unimplemented status code",
                     match &result {
-                        Err(Grpc(status, _)) =>
+                        Err(Grpc(status)) =>
                             status.code() == tower_grpc::Code::Unimplemented,
                         _ => false,
                     },
@@ -625,7 +625,7 @@ impl TestClients {
                 let assertions = vec![test_assert!(
                     "call must fail with unimplemented status code",
                     match &result {
-                        Err(Grpc(status, _)) =>
+                        Err(Grpc(status)) =>
                             status.code() == tower_grpc::Code::Unimplemented,
                         _ => false,
                     },

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -58,6 +58,7 @@ const LARGE_RSP_SIZE: i32 = 314159;
 const REQUEST_LENGTHS: &'static [i32] = &[27182, 8, 1828, 45904];
 const RESPONSE_LENGTHS: &'static [i32] = &[31415, 9, 2653, 58979];
 const TEST_STATUS_MESSAGE: &'static str = "test status message";
+const SPECIAL_TEST_STATUS_MESSAGE: &'static str = "\t\ntest with whitespace\r\nand Unicode BMP ☺ and non-BMP 😈\t\n";
 
 arg_enum!{
     #[derive(Debug, Copy, Clone)]
@@ -596,6 +597,47 @@ impl TestClients {
             })
     }
 
+    fn special_status_message_test(&mut self)
+            -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
+        fn validate_response<T>(result: Result<T, tower_grpc::Error<tower_h2::client::Error>>)
+                -> future::FutureResult<Vec<TestAssertion>, Box<Error>> where T: fmt::Debug {
+            let assertions = vec![
+                test_assert!(
+                    "call must fail with unknown status code",
+                    match &result {
+                        Err(Grpc(status)) =>
+                            status.code() == tower_grpc::Code::Unknown,
+                        _ => false,
+                    },
+                    format!("result={:?}", result)
+                ),
+                test_assert!(
+                    "call must repsond with expected status message",
+                    match &result {
+                        Err(Grpc(status)) =>
+                            status.error_message() == SPECIAL_TEST_STATUS_MESSAGE,
+                        _ => false,
+                    },
+                    format!("result={:?}", result)
+                ),
+            ];
+            future::ok::<Vec<TestAssertion>, Box<Error>>(assertions)
+        }
+
+        let req = SimpleRequest {
+            response_status: Some(pb::EchoStatus {
+                code: 2,
+                message: SPECIAL_TEST_STATUS_MESSAGE.to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        self.test_client
+            .unary_call(Request::new(req.clone()))
+            .then(&validate_response)
+    }
+
     fn unimplemented_method_test(&mut self)
             -> impl Future<Item=Vec<TestAssertion>, Error=Box<Error>> {
         use pb::Empty;
@@ -684,6 +726,8 @@ impl Testcase {
                 core.run(clients.empty_stream_test()),
             Testcase::status_code_and_message =>
                 core.run(clients.status_code_and_message_test()),
+            Testcase::special_status_message =>
+                core.run(clients.special_status_message_test()),
             Testcase::unimplemented_method =>
                 core.run(clients.unimplemented_method_test()),
             Testcase::unimplemented_service =>

--- a/tower-grpc-interop/travis-interop.sh
+++ b/tower-grpc-interop/travis-interop.sh
@@ -24,4 +24,4 @@ trap 'echo ":; killing test server"; kill ${SERVER_PID};' EXIT
 
 # run the interop test client against the server.
 cargo run -p tower-grpc-interop --bin client -- \
-    --test_case=client_streaming,empty_stream,empty_unary,large_unary,ping_pong,server_streaming,status_code_and_message,unimplemented_method,unimplemented_service
+    --test_case=client_streaming,empty_stream,empty_unary,large_unary,ping_pong,server_streaming,status_code_and_message,unimplemented_method,unimplemented_service,special_status_message


### PR DESCRIPTION
* Don't expose `HeaderMap` in the `Error` enum.
* Fix bug/typo that made the library give the status code in the error message field.
* Properly percent decode error messages, and add client interop test for it.