### PR TITLE
Remove one hard Prost dependency from tower-grpc's public interface

### DIFF
--- a/src/client/client_streaming.rs
+++ b/src/client/client_streaming.rs
@@ -51,7 +51,6 @@ where T: Message + Default,
                         .map_err(|e| match e {
                             ::Error::Protocol(p) => ::Error::Protocol(p),
                             ::Error::Inner(()) => ::Error::Protocol(ProtocolError::Internal),
-                            ::Error::Decode(e) => ::Error::Decode(e),
                             ::Error::Grpc(s) => ::Error::Grpc(s),
                         });
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use prost::DecodeError;
 use h2;
 use std;
 use std::fmt;
@@ -7,7 +6,6 @@ use std::fmt;
 pub enum Error<T = ()> {
     Grpc(::Status),
     Protocol(ProtocolError),
-    Decode(DecodeError),
     Inner(T),
 }
 
@@ -33,8 +31,6 @@ impl<T> fmt::Display for Error<T> {
             },
             Error::Protocol(ref _protocol_error) =>
                 f.pad("protocol error"),
-            Error::Decode(ref _decode_error) =>
-                f.pad("message decode error"),
             Error::Inner(ref _inner) =>
                 f.pad("inner error"),
         }
@@ -66,7 +62,6 @@ impl<T> std::error::Error for Error<T> where T : fmt::Debug {
         match *self {
             Error::Grpc(_) => None,
             Error::Protocol(ref protocol_error) => Some(protocol_error),
-            Error::Decode(ref decode_error) => Some(decode_error),
             Error::Inner(ref _inner) => None,
         }
     }

--- a/src/status.rs
+++ b/src/status.rs
@@ -26,6 +26,14 @@ impl Status {
         }
     }
 
+    pub fn with_code_and_message(code: Code, message: String) -> Status {
+        Status {
+            code,
+            error_message: message,
+            binary_error_details: Bytes::new(),
+        }
+    }
+
     pub fn from_header_map(header_map: &HeaderMap) -> Option<Status> {
         header_map.get(GRPC_STATUS_HEADER_CODE).clone().map(|code| {
             let code = ::Code::from_bytes(code.as_ref());


### PR DESCRIPTION
Instead of providing a Prost specific type in the Error type, expose protobuf parse errors as INTERNAL errors, as speced in https://github.com/grpc/grpc/blob/master/doc/statuscodes.md

This is kind of related to #90 but it's not quite that. I care about this because I think the `tower_grpc::Error` type should not exist (it should be replaced by `tower_grpc::Status`): The `Decode` variant is bad because it unnecessarily ties the library's public API to Prost, the `Inner` variant is bad because it forces users of this library to convert between separate tower_grpc `Error` types in ways that don't really make sense.

`Protocol` is not bad in itself, I just don't see when it can be useful: The only reason to expose an enum that is this detailed is if users of tower_grpc would write code that behaves differently for each of these cases, which I doubt. Using only the `Status` type makes the API much easier to work with in almost all use cases, and that is what all of the other gRPC libraries do.