### PR TITLE
Remove tower_grpc::ProtocolError

### DIFF
--- a/src/client/client_streaming.rs
+++ b/src/client/client_streaming.rs
@@ -50,7 +50,8 @@ where T: Message + Default,
                     let res = stream.poll()
                         .map_err(|e| match e {
                             ::Error::Protocol(p) => ::Error::Protocol(p),
-                            ::Error::Inner(()) => ::Error::Protocol(ProtocolError::Internal),
+                            ::Error::Inner(()) => ::Error::Grpc(::Status::with_code(
+                                ::Code::Internal)),
                             ::Error::Grpc(s) => ::Error::Grpc(s),
                         });
 

--- a/src/client/client_streaming.rs
+++ b/src/client/client_streaming.rs
@@ -8,7 +8,6 @@ use bytes::IntoBuf;
 use futures::{Future, Stream, Poll};
 use http::{response, Response};
 use prost::Message;
-use error::ProtocolError;
 
 pub struct ResponseFuture<T, U, B: Body> {
     state: State<T, U, B>,
@@ -57,7 +56,9 @@ where T: Message + Default,
 
                     let message = match try_ready!(res) {
                         Some(message) => message,
-                        None => return Err(::Error::Protocol(ProtocolError::MissingMessage)),
+                        None => return Err(::Error::Grpc(::Status::with_code_and_message(
+                                ::Code::Unimplemented,
+                                "Missing response message.".to_string()))),
                     };
 
                     let head = head.take().unwrap();

--- a/src/client/client_streaming.rs
+++ b/src/client/client_streaming.rs
@@ -48,7 +48,6 @@ where T: Message + Default,
                 WaitMessage { ref mut head, ref mut stream } => {
                     let res = stream.poll()
                         .map_err(|e| match e {
-                            ::Error::Protocol(p) => ::Error::Protocol(p),
                             ::Error::Inner(()) => ::Error::Grpc(::Status::with_code(
                                 ::Code::Internal)),
                             ::Error::Grpc(s) => ::Error::Grpc(s),

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,6 @@ pub enum ProtocolError {
     MissingMessage,
     UnexpectedEof,
     Internal,
-    UnsupportedCompressionFlag(u8),
 }
 
 impl<T> fmt::Display for Error<T> {
@@ -48,8 +47,6 @@ impl fmt::Display for ProtocolError {
                 f.pad("unexpected EOF"),
             ProtocolError::Internal =>
                 f.pad("internal"),
-            ProtocolError::UnsupportedCompressionFlag(flag) =>
-                write!(f, "unsupported compression flag: {}", flag),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,6 @@ pub enum Error<T = ()> {
 
 #[derive(Debug)]
 pub enum ProtocolError {
-    MissingTrailers,
 }
 
 impl<T> fmt::Display for Error<T> {
@@ -34,10 +33,8 @@ impl<T> fmt::Display for Error<T> {
 }
 
 impl fmt::Display for ProtocolError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            ProtocolError::MissingTrailers =>
-                f.pad("missing trailers"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,6 @@ pub enum ProtocolError {
     MissingTrailers,
     MissingMessage,
     UnexpectedEof,
-    Internal,
 }
 
 impl<T> fmt::Display for Error<T> {
@@ -45,8 +44,6 @@ impl fmt::Display for ProtocolError {
                 f.pad("missing message"),
             ProtocolError::UnexpectedEof =>
                 f.pad("unexpected EOF"),
-            ProtocolError::Internal =>
-                f.pad("internal"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,6 @@ pub enum Error<T = ()> {
 #[derive(Debug)]
 pub enum ProtocolError {
     MissingTrailers,
-    UnexpectedEof,
 }
 
 impl<T> fmt::Display for Error<T> {
@@ -39,8 +38,6 @@ impl fmt::Display for ProtocolError {
         match *self {
             ProtocolError::MissingTrailers =>
                 f.pad("missing trailers"),
-            ProtocolError::UnexpectedEof =>
-                f.pad("unexpected EOF"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,6 @@ pub enum Error<T = ()> {
 #[derive(Debug)]
 pub enum ProtocolError {
     MissingTrailers,
-    MissingMessage,
     UnexpectedEof,
 }
 
@@ -40,8 +39,6 @@ impl fmt::Display for ProtocolError {
         match *self {
             ProtocolError::MissingTrailers =>
                 f.pad("missing trailers"),
-            ProtocolError::MissingMessage =>
-                f.pad("missing message"),
             ProtocolError::UnexpectedEof =>
                 f.pad("unexpected EOF"),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,12 +5,7 @@ use std::fmt;
 #[derive(Debug)]
 pub enum Error<T = ()> {
     Grpc(::Status),
-    Protocol(ProtocolError),
     Inner(T),
-}
-
-#[derive(Debug)]
-pub enum ProtocolError {
 }
 
 impl<T> fmt::Display for Error<T> {
@@ -24,29 +19,16 @@ impl<T> fmt::Display for Error<T> {
                     status.error_message()
                 )
             },
-            Error::Protocol(ref _protocol_error) =>
-                f.pad("protocol error"),
             Error::Inner(ref _inner) =>
                 f.pad("inner error"),
         }
     }
 }
 
-impl fmt::Display for ProtocolError {
-    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-        }
-    }
-}
-
-impl std::error::Error for ProtocolError {
-}
-
 impl<T> std::error::Error for Error<T> where T : fmt::Debug {
     fn cause(&self) -> Option<&std::error::Error> {
         match *self {
             Error::Grpc(_) => None,
-            Error::Protocol(ref protocol_error) => Some(protocol_error),
             Error::Inner(ref _inner) => None,
         }
     }

--- a/src/generic/codec.rs
+++ b/src/generic/codec.rs
@@ -8,7 +8,6 @@ use std::collections::VecDeque;
 use std::fmt;
 
 use status::infer_grpc_status;
-use error::ProtocolError;
 
 /// Encodes and decodes gRPC message types
 pub trait Codec {
@@ -335,7 +334,9 @@ where T: Decoder,
             } else {
                 if self.bufs.has_remaining() {
                     trace!("unexpected EOF decoding stream");
-                    return Err(::Error::Protocol(ProtocolError::UnexpectedEof))
+                    return Err(::Error::Grpc(::Status::with_code_and_message(
+                        ::Code::Internal,
+                        "Unexpected EOF decoding stream.".to_string())))
                 } else {
                     self.state = State::Done;
                     break;

--- a/src/generic/codec.rs
+++ b/src/generic/codec.rs
@@ -268,11 +268,15 @@ where T: Decoder,
                 0 => false,
                 1 => {
                     trace!("message compressed, compression not supported yet");
-                    return Err(::Error::Protocol(ProtocolError::UnsupportedCompressionFlag(1)));
+                    return Err(::Error::Grpc(::Status::with_code_and_message(
+                        ::Code::Unimplemented,
+                        "Message compressed, compression not supported yet.".to_string())));
                 },
                 f => {
                     trace!("unexpected compression flag");
-                    return Err(::Error::Protocol(ProtocolError::UnsupportedCompressionFlag(f)));
+                    return Err(::Error::Grpc(::Status::with_code_and_message(
+                        ::Code::Internal,
+                        format!("Unexpected compression flag: {}", f))));
                 }
             };
             let len = self.bufs.get_u32_be() as usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ mod response;
 mod status;
 
 pub use body::{Body, BoxBody};
-pub use error::{Error, ProtocolError};
+pub use error::Error;
 pub use status::{Code, Status};
 pub use request::Request;
 pub use response::Response;


### PR DESCRIPTION
This is the next step in my attempt to eliminate `tower_grpc::Error`, see #6.

After this, the only remaining thing is `tower_grpc::Error::Inner`, which is the trickiest one because `Inner` is kind of inherent to Tower's way of handling errors by wrapping error types in error types, see for example how [tower-timeout](https://github.com/tower-rs/tower/blob/master/tower-timeout/src/lib.rs#L26) does it.