### PR TITLE
Add clone impl for clients when the inner service impls clone

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -10,7 +10,7 @@ use tower_http::HttpService;
 
 use body::{Body, BoxBody};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Grpc<T> {
     /// The inner HTTP/2.0 service.
     inner: T,

--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -51,6 +51,7 @@ impl ServiceGenerator {
             .vis("pub")
             .generic("T")
             .derive("Debug")
+            .derive("Clone")
             .field("inner", "grpc::Grpc<T>")
             ;
     }


### PR DESCRIPTION
This change adds the ability to clone the outter client when the inner service is cloneable. This allows one to embed tower-buffer for example into the inner service to provide a cloneable and buffer backed client.

```rust
    let say_hello = make_client.make_service(())
        .map(move |conn| {
            use hello_world::client::Greeter;
            use tower_http::add_origin;

            let conn = add_origin::Builder::new()
                .uri(uri)
                .build(conn)
                .unwrap();

			let conn = Buffer::new(conn, 100).unwrap();

            Greeter::new(conn)
        })
        .and_then(|client| {
            use hello_world::HelloRequest;

			let mut client = client.clone();

            client.say_hello(Request::new(HelloRequest {
                name: "What is in a name?".to_string(),
            })).map_err(|e| panic!("gRPC request failed; err={:?}", e))
        })
```

This shoud also enable the ability to embed a client into a server for use when calling out to other grpc/tower clients.