### PR TITLE
Support empty protos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
   "tests/collide",
   "tests/name-case",
   "tests/unused-imports",
+  "tests/uses_empty",
 ]
 
 [dependencies]

--- a/tests/uses_empty/Cargo.toml
+++ b/tests/uses_empty/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "uses_empty"
+version = "0.1.0"
+authors = ["Carl Lerche <me@carllerche.com>"]
+publish = false
+
+[dependencies]
+prost-derive = "0.4"
+tower-grpc = { path = "../../" }
+
+[build-dependencies]
+tower-grpc-build = { path = "../../tower-grpc-build" }

--- a/tests/uses_empty/build.rs
+++ b/tests/uses_empty/build.rs
@@ -1,0 +1,9 @@
+extern crate tower_grpc_build;
+
+fn main() {
+    tower_grpc_build::Config::new()
+        .enable_server(true)
+        .enable_client(true)
+        .build(&["proto/uses_empty.proto"], &["proto"])
+        .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
+}

--- a/tests/uses_empty/proto/uses_empty.proto
+++ b/tests/uses_empty/proto/uses_empty.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package uses_empty;
+
+import "google/protobuf/empty.proto";
+
+service UsesEmpty {
+  rpc DoCall(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+}

--- a/tests/uses_empty/src/lib.rs
+++ b/tests/uses_empty/src/lib.rs
@@ -1,0 +1,28 @@
+extern crate prost_derive;
+extern crate tower_grpc;
+
+pub mod uses_empty {
+    include!(concat!(env!("OUT_DIR"), "/uses_empty.rs"));
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn can_call() {
+        use ::uses_empty::client::UsesEmpty;
+        use ::tower_grpc::codegen::client::*;
+        use ::tower_grpc::codegen::client::futures::Future;
+
+        #[allow(dead_code)]
+        fn zomg<T, R>(client: &mut UsesEmpty<T>)
+        where T: tower::HttpService<R>,
+              T::ResponseBody: grpc::Body,
+              grpc::unary::Once<()>: grpc::Encodable<R>
+        {
+            let _ = client.do_call(tower_grpc::Request::new(())).map(|resp| {
+                let inner: () = resp.into_inner();
+                inner
+            });
+        }
+    }
+}

--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -85,8 +85,8 @@ impl ServiceGenerator {
         for method in &service.methods {
             let name = &method.name;
             let path = ::method_path(service, method);
-            let input_type = ::unqualified(&method.input_type, 1);
-            let output_type = ::unqualified(&method.output_type, 1);
+            let input_type = ::unqualified(&method.input_type, &method.input_proto_type, 1);
+            let output_type = ::unqualified(&method.output_type, &method.output_proto_type, 1);
 
             let func = imp.new_fn(&name)
                 .vis("pub")

--- a/tower-grpc-build/src/lib.rs
+++ b/tower-grpc-build/src/lib.rs
@@ -189,7 +189,11 @@ fn super_import(ty: &str, level: usize) -> (String, String) {
     (v.join("::"), ty.to_string())
 }
 
-fn unqualified(ty: &str, level: usize) -> String {
+fn unqualified(ty: &str, proto_ty: &str, level: usize) -> String {
+    if proto_ty == ".google.protobuf.Empty" {
+        return "()".to_string();
+    }
+
     if !is_imported_type(ty) {
         return ty.to_string();
     }


### PR DESCRIPTION
Currently, you need to manually make a type google::protobuf::Empty = ()