### PR TITLE
Derive Clone impl for Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use h2;
 use std;
 use std::fmt;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Error<T = ()> {
     Grpc(::Status),
     Inner(T),


### PR DESCRIPTION
It's sometimes convenient if the whole error value is cloneable (like `Status` is), provided that its `Inner` variant's content is cloneable, which it is by default.