### PR TITLE
Retain protobuf comments

### DIFF
--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -1,4 +1,5 @@
 use codegen;
+use comments_to_rustdoc;
 use prost_build;
 use super::ImportType;
 
@@ -52,11 +53,7 @@ impl ServiceGenerator {
             .generic("T")
             .derive("Debug")
             .derive("Clone")
-            .doc(&service.comments.leading
-                 .iter()
-                 .fold(String::new(), |acc, s|{
-                     acc + s.trim_start() + "\n"
-                 }))
+            .doc(&comments_to_rustdoc(&service.comments.leading))
             .field("inner", "grpc::Grpc<T>")
             ;
     }
@@ -100,11 +97,7 @@ impl ServiceGenerator {
                 .bound("T::ResponseBody", "grpc::Body")
                 .arg_mut_self()
                 .line(format!("let path = http::PathAndQuery::from_static({});", path))
-                .doc(&method.comments.leading
-                     .iter()
-                     .fold(String::new(), |acc, s|{
-                         acc + s.trim_start() + "\n"
-                     }))
+                .doc(&comments_to_rustdoc(&service.comments.leading))
                 ;
 
             let mut request = codegen::Type::new("grpc::Request");

--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -52,6 +52,7 @@ impl ServiceGenerator {
             .generic("T")
             .derive("Debug")
             .derive("Clone")
+            .doc(&service.comments.leading.join(" "))
             .field("inner", "grpc::Grpc<T>")
             ;
     }

--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -53,7 +53,7 @@ impl ServiceGenerator {
             .generic("T")
             .derive("Debug")
             .derive("Clone")
-            .doc(&comments_to_rustdoc(&service.comments.leading))
+            .doc(&comments_to_rustdoc(&service.comments))
             .field("inner", "grpc::Grpc<T>")
             ;
     }
@@ -97,7 +97,7 @@ impl ServiceGenerator {
                 .bound("T::ResponseBody", "grpc::Body")
                 .arg_mut_self()
                 .line(format!("let path = http::PathAndQuery::from_static({});", path))
-                .doc(&comments_to_rustdoc(&service.comments.leading))
+                .doc(&comments_to_rustdoc(&service.comments))
                 ;
 
             let mut request = codegen::Type::new("grpc::Request");

--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -52,7 +52,11 @@ impl ServiceGenerator {
             .generic("T")
             .derive("Debug")
             .derive("Clone")
-            .doc(&service.comments.leading.join(" "))
+            .doc(&service.comments.leading
+                 .iter()
+                 .fold(String::new(), |acc, s|{
+                     acc + s.trim_start() + "\n"
+                 }))
             .field("inner", "grpc::Grpc<T>")
             ;
     }

--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -100,6 +100,11 @@ impl ServiceGenerator {
                 .bound("T::ResponseBody", "grpc::Body")
                 .arg_mut_self()
                 .line(format!("let path = http::PathAndQuery::from_static({});", path))
+                .doc(&method.comments.leading
+                     .iter()
+                     .fold(String::new(), |acc, s|{
+                         acc + s.trim_start() + "\n"
+                     }))
                 ;
 
             let mut request = codegen::Type::new("grpc::Request");

--- a/tower-grpc-build/src/lib.rs
+++ b/tower-grpc-build/src/lib.rs
@@ -225,7 +225,8 @@ fn to_upper_camel(s: &str) -> String {
     ident
 }
 
-/// This function takes an array of comments and properly formats them.
+/// This function takes a `&prost_build::Comments` and formats them as a
+/// `String` to be used as a RustDoc comment.
 fn comments_to_rustdoc(comments: &prost_build::Comments) -> String {
     comments
         .leading

--- a/tower-grpc-build/src/lib.rs
+++ b/tower-grpc-build/src/lib.rs
@@ -224,3 +224,12 @@ fn to_upper_camel(s: &str) -> String {
     }
     ident
 }
+
+/// This function takes an array of comments and properly formats them.
+fn comments_to_rustdoc(comments: &[String]) -> String {
+    comments
+        .iter()
+        .fold(String::new(), |acc, s|{
+            acc + s.trim_start() + "\n"
+        })
+}

--- a/tower-grpc-build/src/lib.rs
+++ b/tower-grpc-build/src/lib.rs
@@ -226,8 +226,9 @@ fn to_upper_camel(s: &str) -> String {
 }
 
 /// This function takes an array of comments and properly formats them.
-fn comments_to_rustdoc(comments: &[String]) -> String {
+fn comments_to_rustdoc(comments: &prost_build::Comments) -> String {
     comments
+        .leading
         .iter()
         .fold(String::new(), |acc, s|{
             acc + s.trim_start() + "\n"

--- a/tower-grpc-build/src/server.rs
+++ b/tower-grpc-build/src/server.rs
@@ -77,7 +77,7 @@ macro_rules! try_ready {
         let mut service_trait = codegen::Trait::new(&service.name);
         service_trait.vis("pub")
             .parent("Clone")
-            .doc(&comments_to_rustdoc(&service.comments.leading))
+            .doc(&comments_to_rustdoc(&service.comments))
             ;
 
         for method in &service.methods {
@@ -129,7 +129,7 @@ macro_rules! try_ready {
                 .arg_mut_self()
                 .arg("request", &request_type)
                 .ret(&format!("Self::{}Future", &upper_name))
-                .doc(&comments_to_rustdoc(&method.comments.leading))
+                .doc(&comments_to_rustdoc(&method.comments))
                 ;
         }
 

--- a/tower-grpc-build/src/server.rs
+++ b/tower-grpc-build/src/server.rs
@@ -132,6 +132,11 @@ macro_rules! try_ready {
                 .arg_mut_self()
                 .arg("request", &request_type)
                 .ret(&format!("Self::{}Future", &upper_name))
+                .doc(&method.comments.leading
+                     .iter()
+                     .fold(String::new(), |acc, s|{
+                         acc + s.trim_start() + "\n"
+                     }))
                 ;
         }
 

--- a/tower-grpc-build/src/server.rs
+++ b/tower-grpc-build/src/server.rs
@@ -76,6 +76,11 @@ macro_rules! try_ready {
         let mut service_trait = codegen::Trait::new(&service.name);
         service_trait.vis("pub")
             .parent("Clone")
+            .doc(&service.comments.leading
+                 .iter()
+                 .fold(String::new(), |acc, s|{
+                     acc + s.trim_start() + "\n"
+                 }))
             ;
 
         for method in &service.methods {

--- a/tower-grpc-build/src/server.rs
+++ b/tower-grpc-build/src/server.rs
@@ -1,4 +1,5 @@
 use codegen;
+use comments_to_rustdoc;
 use prost_build;
 use super::ImportType;
 
@@ -76,11 +77,7 @@ macro_rules! try_ready {
         let mut service_trait = codegen::Trait::new(&service.name);
         service_trait.vis("pub")
             .parent("Clone")
-            .doc(&service.comments.leading
-                 .iter()
-                 .fold(String::new(), |acc, s|{
-                     acc + s.trim_start() + "\n"
-                 }))
+            .doc(&comments_to_rustdoc(&service.comments.leading))
             ;
 
         for method in &service.methods {
@@ -132,11 +129,7 @@ macro_rules! try_ready {
                 .arg_mut_self()
                 .arg("request", &request_type)
                 .ret(&format!("Self::{}Future", &upper_name))
-                .doc(&method.comments.leading
-                     .iter()
-                     .fold(String::new(), |acc, s|{
-                         acc + s.trim_start() + "\n"
-                     }))
+                .doc(&comments_to_rustdoc(&method.comments.leading))
                 ;
         }
 


### PR DESCRIPTION
grpc-build: generated code comments for methods, structs, and traits

Currently, the Rust code generated from protobuf files with comments
doesn't include the comments.

This branch fixes this by including the comments for
methods and structs on the client side and methods and traits on the
server side. This is done by calling doc on the sections of code that
generate new functions, structs, and traits. In the proto file, the
service comments are used for the structs and traits and the functions
comments inside those services are for the comments on methods. This
handles multiline comments that start immediately before functions
and services.

Fixes: #96