### PR TITLE
Remove the `do not use` disclaimer from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,6 @@ More information about this crate can be found in the [crate documentation][dox]
 
 [dox]: https://tower-rs.github.io/tower-grpc/tower_grpc
 
-**This library is not production ready. Do not try to use it in a production
-environment or you will regret it!** This crate is still under active
-development and there has not yet been any focus on documentation (because you
-shouldn't be using it yet!).
-
 ## License
 
 This project is licensed under the [MIT license](LICENSE).


### PR DESCRIPTION
We don't really need this line in the readme anymore, this library and tower is stable enough to support production use as showed by linkerd.