### PR TITLE
Allow Clients to pass Request<M> or M

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -1,6 +1,7 @@
 use http;
 use metadata::MetadataMap;
 
+/// A gRPC request containing an message and metadata.
 #[derive(Debug)]
 pub struct Request<T> {
     metadata: MetadataMap,
@@ -70,5 +71,11 @@ impl<T> Request<T> {
             metadata: self.metadata,
             message,
         }
+    }
+}
+
+impl<T> From<T> for Request<T> {
+    fn from(msg: T) -> Self {
+        Request::new(msg)
     }
 }

--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -99,6 +99,7 @@ impl ServiceGenerator {
                 .bound("T::Error", "Into<Box<::std::error::Error>>")
                 .arg_mut_self()
                 .line(format!("let path = http::PathAndQuery::from_static({});", path))
+                .line("let request = Into::into(request);")
                 .doc(&comments_to_rustdoc(&service.comments))
                 ;
 
@@ -161,7 +162,9 @@ impl ServiceGenerator {
                 }
             };
 
-            func.arg("request", request)
+            func.generic("__Req")
+                .arg("request", "__Req")
+                .bound("__Req", &*codegen::Type::new("Into").generic(&request))
                 .bound(&req_body, "grpc::Encodable<R>");
         }
     }

--- a/tower-grpc-examples/src/helloworld/client.rs
+++ b/tower-grpc-examples/src/helloworld/client.rs
@@ -16,7 +16,6 @@ extern crate tower_util;
 use futures::{Future, Poll};
 use tokio::executor::DefaultExecutor;
 use tokio::net::tcp::{ConnectFuture, TcpStream};
-use tower_grpc::Request;
 use tower_h2::client;
 use tower_service::Service;
 use tower_util::MakeService;
@@ -48,9 +47,9 @@ pub fn main() {
         .and_then(|mut client| {
             use hello_world::HelloRequest;
 
-            client.say_hello(Request::new(HelloRequest {
+            client.say_hello(HelloRequest {
                 name: "What is in a name?".to_string(),
-            })).map_err(|e| panic!("gRPC request failed; err={:?}", e))
+            }).map_err(|e| panic!("gRPC request failed; err={:?}", e))
         })
         .and_then(|response| {
             println!("RESPONSE = {:?}", response);

--- a/tower-grpc-examples/src/routeguide/client.rs
+++ b/tower-grpc-examples/src/routeguide/client.rs
@@ -24,7 +24,6 @@ extern crate serde_derive;
 use futures::{Future, Poll};
 use tokio::executor::DefaultExecutor;
 use tokio::net::tcp::{ConnectFuture, TcpStream};
-use tower_grpc::Request;
 use tower_h2::client;
 use tower_service::Service;
 use tower_util::MakeService;
@@ -59,10 +58,10 @@ pub fn main() {
         })
         .and_then(|mut client| {
             client
-                .get_feature(Request::new(Point {
+                .get_feature(Point {
                     latitude: 409146138,
                     longitude: -746188906,
-                }))
+                })
                 .map_err(|e| panic!("gRPC request failed; err={:?}", e))
         })
         .map(|response| {


### PR DESCRIPTION
I can't decide if this is a good idea or not. At first thought, it sounds nice, since it allows users to skip importing and creating a `grpc::Request` if they don't need to set any metadata...