### PR TITLE
Impl for hyper::Body

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ authors = [
 license = "MIT"
 
 [features]
-default = ["protobuf", "tower-h2"]
+default = ["protobuf", "tower-h2", "hyper-body"]
+hyper-body = ["hyper"]
 protobuf = ["prost"]
 
 [workspace]
@@ -34,6 +35,7 @@ http = "0.1.14"
 h2 = "0.1.11"
 log = "0.4"
 percent-encoding = "1.0.1"
+hyper = { version = "0.12.25", optional = true }
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2", optional = true }
 tower-http = { git = "https://github.com/tower-rs/tower-http" }
 tower-service = { git = "https://github.com/tower-rs/tower"  }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -54,6 +54,13 @@ pub mod server {
     pub mod tower_h2 {
         pub use ::tower_h2::{Body, RecvBody};
     }
+
+    #[cfg(feature = "hyper-body")]
+    pub mod hyper {
+        pub use bytes::Buf;
+        pub use hyper::{Error, Body};
+        pub use hyper::body::Payload;
+    }
 }
 
 pub mod client {
@@ -87,5 +94,11 @@ pub mod client {
     /// Re-exported types from `tower-h2` crate.
     pub mod tower_h2 {
         pub use ::tower_h2::Body;
+    }
+
+    #[cfg(feature = "hyper-body")]
+    pub mod hyper {
+        pub use hyper::{Body, Error};
+        pub use hyper::body::Payload;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, missing_debug_implementations)]
+#![deny(missing_debug_implementations)]
 //#![deny(missing_docs)]
 
 extern crate base64;
@@ -14,10 +14,12 @@ extern crate tower_http;
 extern crate tower_service;
 extern crate tower_util;
 
-#[cfg(feature = "tower-h2")]
-extern crate tower_h2;
+#[cfg(feature = "hyper-body")]
+extern crate hyper;
 #[cfg(feature = "protobuf")]
 extern crate prost;
+#[cfg(feature = "tower-h2")]
+extern crate tower_h2;
 
 pub mod client;
 pub mod generic;
@@ -28,8 +30,8 @@ mod request;
 mod response;
 mod status;
 
+pub use status::{Status, Code};
 pub use body::{Body, BoxBody};
-pub use status::{Code, Status};
 pub use request::Request;
 pub use response::Response;
 

--- a/tower-grpc-build/Cargo.toml
+++ b/tower-grpc-build/Cargo.toml
@@ -10,5 +10,6 @@ prost-build = "0.4"
 heck = "0.3"
 
 [features]
-default = ["tower-h2"]
+default = ["tower-h2", "hyper-body"]
 tower-h2 = []
+hyper-body = []


### PR DESCRIPTION
This adds a feature for an optional impl of `hyper::Body` I don't think this is 100% correct so I'm expecting to have to do some more work on this, but for the most part it at least compiles and generates compilable code. The impl gives a recursion which is probably possible to remove, but I'm not sure how to accomplish that.

Also, how is testing setup for the project? I'm not sure where tests for this should live.