### PR TITLE
Fix server's generated unimplemented catch-all

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -10,11 +10,11 @@ pub mod server {
             ServerStreamingService,
         };
         pub use ::server::{
-            Grpc,
             unary,
             client_streaming,
             server_streaming,
             streaming,
+            unimplemented,
         };
         pub use ::codec::{
             Encode,

--- a/src/generic/server/grpc.rs
+++ b/src/generic/server/grpc.rs
@@ -6,7 +6,7 @@ use generic::server::{StreamingService, ServerStreamingService, ClientStreamingS
 use http;
 
 #[derive(Debug, Clone)]
-pub struct Grpc<T> {
+pub(crate) struct Grpc<T> {
     codec: T,
 }
 
@@ -15,11 +15,11 @@ pub struct Grpc<T> {
 impl<T> Grpc<T>
 where T: Codec,
 {
-    pub fn new(codec: T) -> Self {
+    pub(crate) fn new(codec: T) -> Self {
         Grpc { codec }
     }
 
-    pub fn unary<S, B>(&mut self,
+    pub(crate) fn unary<S, B>(&mut self,
                        service: S,
                        request: http::Request<B>)
         -> unary::ResponseFuture<S, T::Encoder, Streaming<T::Decoder, B>>
@@ -31,7 +31,7 @@ where T: Codec,
         unary::ResponseFuture::new(service, request, self.codec.encoder())
     }
 
-    pub fn client_streaming<S, B>(&mut self,
+    pub(crate) fn client_streaming<S, B>(&mut self,
                                service: &mut S,
                                request: http::Request<B>)
         -> client_streaming::ResponseFuture<S::Future, T::Encoder>
@@ -43,7 +43,7 @@ where T: Codec,
         client_streaming::ResponseFuture::new(response, self.codec.encoder())
     }
 
-    pub fn server_streaming<S, B>(&mut self,
+    pub(crate) fn server_streaming<S, B>(&mut self,
                                   service: S,
                                   request: http::Request<B>)
         -> server_streaming::ResponseFuture<S, T::Encoder, Streaming<T::Decoder, B>>
@@ -55,7 +55,7 @@ where T: Codec,
         server_streaming::ResponseFuture::new(service, request, self.codec.encoder())
     }
 
-    pub fn streaming<S, B>(&mut self,
+    pub(crate) fn streaming<S, B>(&mut self,
                            service: &mut S,
                            request: http::Request<B>)
         -> streaming::ResponseFuture<S::Future, T::Encoder>

--- a/src/generic/server/mod.rs
+++ b/src/generic/server/mod.rs
@@ -1,11 +1,11 @@
 mod grpc;
 
-pub mod client_streaming;
-pub mod server_streaming;
-pub mod streaming;
-pub mod unary;
+pub(crate) mod client_streaming;
+pub(crate) mod server_streaming;
+pub(crate) mod streaming;
+pub(crate) mod unary;
 
-pub use self::grpc::Grpc;
+pub(crate) use self::grpc::Grpc;
 
 use {Request, Response};
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2,79 +2,73 @@ pub mod client_streaming;
 pub mod server_streaming;
 pub mod streaming;
 pub mod unary;
+pub mod unimplemented;
 
 use Body;
 use codec::{Codec, Streaming};
-use generic::server::{UnaryService, ClientStreamingService, ServerStreamingService, StreamingService};
+use generic::server::{
+    Grpc,
+    UnaryService,
+    ClientStreamingService,
+    ServerStreamingService,
+    StreamingService,
+};
 
 use http;
 use prost;
 
-#[derive(Debug, Clone)]
-pub struct Grpc {
-    _p: (),
+pub fn unary<T, B, R>(service: T,
+                   request: http::Request<B>)
+    -> unary::ResponseFuture<T, B, R>
+where T: UnaryService<R>,
+      R: prost::Message + Default,
+      T::Response: prost::Message,
+      B: Body,
+{
+    let mut grpc = Grpc::new(Codec::new());
+    let inner = grpc.unary(service, request);
+    unary::ResponseFuture::new(inner)
 }
 
-// ===== impl Grpc =====
+pub fn client_streaming<T, R, B>(service: &mut T,
+                                 request: http::Request<B>)
+    -> client_streaming::ResponseFuture<T, Streaming<R, B>>
+where T: ClientStreamingService<Streaming<R, B>>,
+      R: prost::Message + Default,
+      T::Response: prost::Message,
+      B: Body,
+{
+    let mut grpc = Grpc::new(Codec::new());
+    let inner = grpc.client_streaming(service, request);
+    client_streaming::ResponseFuture::new(inner)
+}
 
-impl Grpc {
-    pub fn unary<T, B, R>(service: T,
-                       request: http::Request<B>)
-        -> unary::ResponseFuture<T, B, R>
-    where T: UnaryService<R>,
-          R: prost::Message + Default,
-          T::Response: prost::Message,
-          B: Body,
-    {
-        use generic::server::Grpc;
-
-        let mut grpc = Grpc::new(Codec::new());
-        let inner = grpc.unary(service, request);
-        unary::ResponseFuture::new(inner)
-    }
-
-    pub fn client_streaming<T, R, B>(service: &mut T,
-                                     request: http::Request<B>)
-        -> client_streaming::ResponseFuture<T, Streaming<R, B>>
-    where T: ClientStreamingService<Streaming<R, B>>,
-          R: prost::Message + Default,
-          T::Response: prost::Message,
-          B: Body,
-    {
-        use generic::server::Grpc;
-
-        let mut grpc = Grpc::new(Codec::new());
-        let inner = grpc.client_streaming(service, request);
-        client_streaming::ResponseFuture::new(inner)
-    }
-
-    pub fn server_streaming<T, B, R>(service: T,
-                                  request: http::Request<B>)
-        -> server_streaming::ResponseFuture<T, B, R>
-    where T: ServerStreamingService<R>,
-          R: prost::Message + Default,
-          T::Response: prost::Message,
-          B: Body,
-    {
-        use generic::server::Grpc;
-
-        let mut grpc = Grpc::new(Codec::new());
-        let inner = grpc.server_streaming(service, request);
-        server_streaming::ResponseFuture::new(inner)
-    }
-
-    pub fn streaming<T, R, B>(service: &mut T,
+pub fn server_streaming<T, B, R>(service: T,
                               request: http::Request<B>)
-        -> streaming::ResponseFuture<T, Streaming<R, B>>
-    where T: StreamingService<Streaming<R, B>>,
-          R: prost::Message + Default,
-          T::Response: prost::Message,
-          B: Body,
-    {
-        use generic::server::Grpc;
+    -> server_streaming::ResponseFuture<T, B, R>
+where T: ServerStreamingService<R>,
+      R: prost::Message + Default,
+      T::Response: prost::Message,
+      B: Body,
+{
+    let mut grpc = Grpc::new(Codec::new());
+    let inner = grpc.server_streaming(service, request);
+    server_streaming::ResponseFuture::new(inner)
+}
 
-        let mut grpc = Grpc::new(Codec::new());
-        let inner = grpc.streaming(service, request);
-        streaming::ResponseFuture::new(inner)
-    }
+pub fn streaming<T, R, B>(service: &mut T,
+                          request: http::Request<B>)
+    -> streaming::ResponseFuture<T, Streaming<R, B>>
+where T: StreamingService<Streaming<R, B>>,
+      R: prost::Message + Default,
+      T::Response: prost::Message,
+      B: Body,
+{
+    let mut grpc = Grpc::new(Codec::new());
+    let inner = grpc.streaming(service, request);
+    streaming::ResponseFuture::new(inner)
+}
+
+pub fn unimplemented(message: String) -> unimplemented::ResponseFuture {
+    unimplemented::ResponseFuture::new(message)
 }

--- a/src/server/unimplemented.rs
+++ b/src/server/unimplemented.rs
@@ -1,0 +1,30 @@
+use futures::{Future, Poll};
+use {h2, http};
+
+use {Code, Status};
+
+#[derive(Debug)]
+pub struct ResponseFuture {
+    status: Option<Status>,
+}
+
+impl ResponseFuture {
+    pub(crate) fn new(msg: String) -> Self {
+        ResponseFuture {
+            status: Some(Status::new(Code::Unimplemented, msg)),
+        }
+    }
+}
+
+impl Future for ResponseFuture {
+    type Item = http::Response<()>;
+    type Error = h2::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let status = self.status.take().expect("polled after complete");
+
+        let mut resp = http::Response::new(());
+        status.add_header(resp.headers_mut())?;
+        Ok(resp.into())
+    }
+}

--- a/src/status.rs
+++ b/src/status.rs
@@ -121,7 +121,11 @@ impl Status {
     // TODO: It would be nice for this not to be public
     pub fn to_header_map(&self) -> Result<HeaderMap, Self> {
         let mut header_map = HeaderMap::with_capacity(3);
+        self.add_header(&mut header_map)?;
+        Ok(header_map)
+    }
 
+    pub(crate) fn add_header(&self, header_map: &mut HeaderMap) -> Result<(), Self> {
         header_map.insert(GRPC_STATUS_HEADER_CODE, self.code.to_header_value());
 
         if !self.message.is_empty() {
@@ -132,7 +136,8 @@ impl Status {
             header_map.insert(GRPC_STATUS_DETAILS_HEADER, HeaderValue::from_shared(self.details.clone())
                 .map_err(invalid_header_value_byte)?);
         }
-        Ok(header_map)
+
+        Ok(())
     }
 }
 

--- a/tower-grpc-interop/Cargo.toml
+++ b/tower-grpc-interop/Cargo.toml
@@ -8,6 +8,10 @@ license = "MIT"
 name = "client"
 path = "src/client.rs"
 
+[[bin]]
+name = "server"
+path = "src/server.rs"
+
 [dependencies]
 futures = "0.1.23"
 bytes = "0.4"
@@ -17,6 +21,7 @@ http = "0.1"
 prost = "0.4"
 prost-derive = "0.4"
 tokio-core = "0.1"
+tokio = "0.1"
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-add-origin = { git = "https://github.com/tower-rs/tower-http" }
 tower-grpc = { path = "../" }

--- a/tower-grpc-interop/build.rs
+++ b/tower-grpc-interop/build.rs
@@ -1,10 +1,20 @@
 extern crate tower_grpc_build;
 
 fn main() {
+    let files = &[
+        "proto/grpc/testing/test.proto",
+    ];
+    let dirs = &["proto/grpc/testing"];
+
     // Build grpc-interop
     tower_grpc_build::Config::new()
         .enable_server(true)
         .enable_client(true)
-        .build(&["proto/grpc/testing/test.proto"], &["proto/grpc/testing"])
+        .build(files, dirs)
         .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
+
+    // prevent needing to rebuild if files (or deps) haven't changed
+    for file in files {
+        println!("cargo:rerun-if-changed={}", file);
+    }
 }

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -557,7 +557,7 @@ impl TestClients {
                     "call must repsond with expected status message",
                     match &result {
                         Err(status) =>
-                            status.error_message() == TEST_STATUS_MESSAGE,
+                            status.message() == TEST_STATUS_MESSAGE,
                         _ => false,
                     },
                     format!("result={:?}", result)
@@ -584,7 +584,7 @@ impl TestClients {
             .and_then(|response_stream| {
                 // Convert the stream into a plain Vec
                 response_stream.into_inner()
-                    .map_err(|_error| panic!("Inner stream should not error!"))
+                    .map_err(From::from)
                     .collect()
             })
             .then(&validate_response);
@@ -614,7 +614,7 @@ impl TestClients {
                     "call must repsond with expected status message",
                     match &result {
                         Err(status) =>
-                            status.error_message() == SPECIAL_TEST_STATUS_MESSAGE,
+                            status.message() == SPECIAL_TEST_STATUS_MESSAGE,
                         _ => false,
                     },
                     format!("result={:?}", result)

--- a/tower-grpc-interop/src/server.rs
+++ b/tower-grpc-interop/src/server.rs
@@ -1,13 +1,173 @@
 #[macro_use]
+extern crate clap;
+extern crate futures;
+#[macro_use]
 extern crate log;
+extern crate pretty_env_logger;
 extern crate prost;
 #[macro_use]
 extern crate prost_derive;
-extern crate tokio_core;
-extern crate tower;
+extern crate tokio;
 extern crate tower_h2;
 extern crate tower_grpc;
 
-mod test {
-    include!(concat!(env!("OUT_DIR"), "/test.rs"));
+use futures::{future, Future, Stream};
+use tokio::executor::DefaultExecutor;
+use tokio::net::TcpListener;
+use tower_h2::Server;
+use tower_grpc::{Request, Response};
+
+mod pb {
+    #![allow(dead_code)]
+    #![allow(unused_imports)]
+    include!(concat!(env!("OUT_DIR"), "/grpc.testing.rs"));
+}
+
+type GrpcFut<T> = Box<dyn Future<Item = tower_grpc::Response<T>, Error = tower_grpc::Status> + Send>;
+type GrpcStream<T> = Box<dyn Stream<Item = T, Error = tower_grpc::Status> + Send>;
+
+macro_rules! todo {
+    ($($piece:tt)+) => ({
+        let msg = format!(
+            "server test case is not supported yet: {}",
+            format_args!($($piece)+),
+        );
+        eprintln!("TODO! {}", msg);
+        return Box::new(future::err(tower_grpc::Status::new(
+            tower_grpc::Code::Unknown,
+            msg,
+        )));
+    })
+}
+
+#[derive(Clone)]
+struct Test;
+
+impl pb::server::TestService for Test {
+    type EmptyCallFuture = GrpcFut<pb::Empty>;
+    type UnaryCallFuture = GrpcFut<pb::SimpleResponse>;
+    type CacheableUnaryCallFuture = GrpcFut<pb::SimpleResponse>;
+    type StreamingOutputCallStream = GrpcStream<pb::StreamingOutputCallResponse>;
+    type StreamingOutputCallFuture = GrpcFut<Self::StreamingOutputCallStream>;
+    type StreamingInputCallFuture = GrpcFut<pb::StreamingInputCallResponse>;
+    type FullDuplexCallStream = GrpcStream<pb::StreamingOutputCallResponse>;
+    type FullDuplexCallFuture = GrpcFut<Self::FullDuplexCallStream>;
+    type HalfDuplexCallStream = GrpcStream<pb::StreamingOutputCallResponse>;
+    type HalfDuplexCallFuture = GrpcFut<Self::HalfDuplexCallStream>;
+    type UnimplementedCallFuture = GrpcFut<pb::Empty>;
+
+    /// One empty request followed by one empty response.
+    fn empty_call(&mut self, _request: Request<pb::Empty>) -> Self::EmptyCallFuture {
+        eprintln!("empty_call");
+        Box::new(future::ok(Response::new(pb::Empty::default())))
+    }
+
+    /// One request followed by one response.
+    fn unary_call(&mut self, request: Request<pb::SimpleRequest>) -> Self::UnaryCallFuture {
+        eprintln!("unary_call");
+        let req = request.into_inner();
+        let res_size = if req.response_size >= 0 {
+            req.response_size as usize
+        } else {
+            let status = tower_grpc::Status::new(
+                tower_grpc::Code::InvalidArgument,
+                "response_size cannot be negative",
+            );
+            return Box::new(future::err(status));
+        };
+
+        let res = pb::SimpleResponse {
+            payload: Some(pb::Payload {
+                body: vec![0; res_size],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        Box::new(future::ok(Response::new(res)))
+    }
+
+    /// One request followed by one response. Response has cache control
+    /// headers set such that a caching HTTP proxy (such as GFE) can
+    /// satisfy subsequent requests.
+    fn cacheable_unary_call(&mut self, _request: Request<pb::SimpleRequest>) -> Self::CacheableUnaryCallFuture {
+        todo!("cacheable_unary_call");
+    }
+
+    /// One request followed by a sequence of responses (streamed download).
+    /// The server returns the payload with client desired type and sizes.
+    fn streaming_output_call(&mut self, _request: Request<pb::StreamingOutputCallRequest>) -> Self::StreamingOutputCallFuture {
+        todo!("streaming_output_call");
+    }
+
+    /// A sequence of requests followed by one response (streamed upload).
+    /// The server returns the aggregated size of client payload as the result.
+    fn streaming_input_call(&mut self, _request: Request<tower_grpc::Streaming<pb::StreamingInputCallRequest>>) -> Self::StreamingInputCallFuture {
+        todo!("streaming_input_call");
+    }
+
+    /// A sequence of requests with each request served by the server immediately.
+    /// As one request could lead to multiple responses, this interface
+    /// demonstrates the idea of full duplexing.
+    fn full_duplex_call(&mut self, _request: Request<tower_grpc::Streaming<pb::StreamingOutputCallRequest>>) -> Self::FullDuplexCallFuture {
+        todo!("full_duplex_call");
+    }
+
+    /// A sequence of requests followed by a sequence of responses.
+    /// The server buffers all the client requests and then serves them in order. A
+    /// stream of responses are returned to the client when the server starts with
+    /// first request.
+    fn half_duplex_call(&mut self, _request: Request<tower_grpc::Streaming<pb::StreamingOutputCallRequest>>) -> Self::HalfDuplexCallFuture {
+        todo!("half_duplex_call");
+    }
+
+    /// The test server will not implement this method. It will be used
+    /// to test the behavior when clients call unimplemented methods.
+    fn unimplemented_call(&mut self, _request: Request<pb::Empty>) -> Self::UnimplementedCallFuture {
+        eprintln!("unimplemented_call");
+        Box::new(future::err(tower_grpc::Status::new(
+            tower_grpc::Code::Unimplemented,
+            "explicitly unimplemented_call",
+        )))
+    }
+}
+
+fn main() {
+    use clap::{Arg, App};
+    let _ = ::pretty_env_logger::init();
+
+    let matches = App::new("interop-server")
+        .arg(Arg::with_name("port")
+            .long("port")
+            .value_name("PORT")
+            .help("The server port to listen on. For example, \"8080\".")
+            .takes_value(true)
+            .default_value("10000")
+        )
+        .get_matches();
+
+    let port = value_t!(matches, "port", u16).expect("port argument");
+
+    let new_service = pb::server::TestServiceServer::new(Test);
+
+    let h2_settings = Default::default();
+    let mut h2 = Server::new(new_service, h2_settings, DefaultExecutor::current());
+
+    let addr = format!("0.0.0.0:{}", port).parse().unwrap();
+    let bind = TcpListener::bind(&addr).expect("bind");
+
+    let serve = bind.incoming()
+        .for_each(move |sock| {
+            if let Err(e) = sock.set_nodelay(true) {
+                return Err(e);
+            }
+
+            let serve = h2.serve(sock);
+            tokio::spawn(serve.map_err(|e| error!("h2 error: {:?}", e)));
+
+            Ok(())
+        })
+        .map_err(|e| eprintln!("accept error: {}", e));
+
+    eprintln!("grpc interop server listening on {}", addr);
+    tokio::run(serve)
 }

--- a/tower-grpc-interop/travis-interop.sh
+++ b/tower-grpc-interop/travis-interop.sh
@@ -3,6 +3,19 @@
 set -eu
 set -o pipefail
 
+# test the tower-grpc interop server first
+cargo build -p tower-grpc-interop --bin server
+./target/debug/server &
+TOWER_SERVER_PID=$!
+echo ":; started tower-grpc test server."
+
+# run the interop test client against the server.
+cargo run -p tower-grpc-interop --bin client -- \
+    --test_case=empty_unary,large_unary,unimplemented_method,unimplemented_service
+
+echo ":; killing tower-grpc test server";
+kill ${TOWER_SERVER_PID};
+
 SERVER="interop-server-go-linux-amd64"
 SERVER_ZIP_URL="https://github.com/tower-rs/tower-grpc/files/1616271/interop-server-go-linux-amd64.zip"
 


### PR DESCRIPTION
Previously, since the generated error body would yield `true` for
`is_end_stream`, the `grpc-status` would never be sent in the trailers.

This adds some basic server interop tests which would see this bug.