### PR TITLE
Generate type-safe bounds for Client Streaming RPCs

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -77,7 +77,7 @@ pub mod client {
 
     /// Re-export types from the `future` crate.
     pub mod futures {
-        pub use ::futures::{Future, Poll};
+        pub use ::futures::{Stream, Future, Poll};
     }
 
     pub mod tower {

--- a/tower-grpc-build/src/client.rs
+++ b/tower-grpc-build/src/client.rs
@@ -36,10 +36,7 @@ impl ServiceGenerator {
                             scope: &mut codegen::Scope)
     {
         for method in &service.methods {
-            if !method.client_streaming {
-                scope.import_type(&method.input_type, 1);
-            }
-
+            scope.import_type(&method.input_type, 1);
             scope.import_type(&method.output_type, 1);
         }
     }
@@ -139,6 +136,10 @@ impl ServiceGenerator {
                     request.generic("B");
 
                     func.generic("B")
+                        .bound("B", &format!(
+                            "futures::Stream<Item = {}>",
+                            input_type,
+                        ))
                         .ret(ret)
                         .line("self.inner.client_streaming(request, path)")
                         ;
@@ -153,6 +154,10 @@ impl ServiceGenerator {
                     request.generic("B");
 
                     func.generic("B")
+                        .bound("B", &format!(
+                            "futures::Stream<Item = {}>",
+                            input_type,
+                        ))
                         .ret(ret)
                         .line("self.inner.streaming(request, path)")
                         ;

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -566,7 +566,16 @@ impl TestClients {
             future::ok::<Vec<TestAssertion>, Box<Error>>(assertions)
         }
 
-        let req = SimpleRequest {
+        let simple_req = SimpleRequest {
+            response_status: Some(pb::EchoStatus {
+                code: 2,
+                message: TEST_STATUS_MESSAGE.to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let duplex_req = pb::StreamingOutputCallRequest {
             response_status: Some(pb::EchoStatus {
                 code: 2,
                 message: TEST_STATUS_MESSAGE.to_string(),
@@ -576,11 +585,11 @@ impl TestClients {
         };
 
         let unary_call = self.test_client
-            .unary_call(Request::new(req.clone()))
+            .unary_call(Request::new(simple_req))
             .then(&validate_response);
 
         let full_duplex_call = self.test_client
-            .full_duplex_call(Request::new(stream::iter_ok(vec![req])))
+            .full_duplex_call(Request::new(stream::iter_ok(vec![duplex_req])))
             .and_then(|response_stream| {
                 // Convert the stream into a plain Vec
                 response_stream.into_inner()


### PR DESCRIPTION
Closes #73