### PR TITLE
Replace server future's errors with Never

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2,7 +2,7 @@
 pub mod server {
     /// Re-export types from this crate
     pub mod grpc {
-        pub use ::{Body, BoxBody, Request, Response, Code, Status};
+        pub use ::{Body, BoxBody, error::Never, Request, Response, Code, Status};
         pub use ::generic::server::{
             StreamingService,
             UnaryService,
@@ -31,11 +31,6 @@ pub mod server {
     /// Re-exported types from the `http` crate.
     pub mod http {
         pub use ::http::{Request, Response, HeaderMap};
-    }
-
-    /// Re-exported types from the `h2` crate.
-    pub mod h2 {
-        pub use ::h2::Error;
     }
 
     /// Re-exported types from the `tower` crate.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,1 +1,14 @@
+use std::fmt;
+
 pub(crate) type Error = Box<dyn std::error::Error + Send + Sync>;
+
+#[derive(Debug)]
+pub enum Never {}
+
+impl fmt::Display for Never {
+    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        match *self {}
+    }
+}
+
+impl std::error::Error for Never {}

--- a/src/generic/server/client_streaming.rs
+++ b/src/generic/server/client_streaming.rs
@@ -3,7 +3,7 @@ use super::streaming;
 use super::unary::Once;
 use generic::{Encoder, Encode};
 
-use {h2, http};
+use {http};
 use futures::{Future, Poll};
 
 #[derive(Debug)]
@@ -34,7 +34,7 @@ where T: Future<Item = Response<E::Item>, Error = ::Status>,
       E: Encoder,
 {
     type Item = http::Response<Encode<E, Once<E::Item>>>;
-    type Error = h2::Error;
+    type Error = ::error::Never;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         self.inner.poll()

--- a/src/generic/server/server_streaming.rs
+++ b/src/generic/server/server_streaming.rs
@@ -3,7 +3,7 @@ use super::streaming;
 use generic::{Encoder, Encode};
 use generic::server::ServerStreamingService;
 
-use {h2, http};
+use {http};
 use futures::{Future, Stream, Poll};
 
 use std::fmt;
@@ -59,7 +59,7 @@ where T: ServerStreamingService<S::Item, Response = E::Item>,
       S: Stream<Error = ::Status>,
 {
     type Item = http::Response<Encode<E, T::ResponseStream>>;
-    type Error = h2::Error;
+    type Error = ::error::Never;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         self.inner.poll()

--- a/src/generic/server/streaming.rs
+++ b/src/generic/server/streaming.rs
@@ -1,8 +1,8 @@
 use {Response};
-use error::Error;
+use error::{Error, Never};
 use generic::{Encoder, Encode};
 
-use {http, h2};
+use {http};
 use futures::{Future, Stream, Poll, Async};
 use http::header;
 
@@ -36,7 +36,7 @@ where T: Future<Item = Response<S>,
       S::Error: Into<Error>,
 {
     type Item = http::Response<Encode<E, S>>;
-    type Error = h2::Error;
+    type Error = Never;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         // Get the gRPC response

--- a/src/generic/server/unary.rs
+++ b/src/generic/server/unary.rs
@@ -3,7 +3,7 @@ use super::server_streaming;
 use generic::{Encoder, Encode};
 use generic::server::UnaryService;
 
-use {h2, http};
+use {http};
 use futures::{Future, Stream, Poll};
 use tower_service::Service;
 
@@ -49,7 +49,7 @@ where T: UnaryService<S::Item, Response = E::Item>,
       S: Stream<Error = ::Status>,
 {
     type Item = http::Response<Encode<E, Once<T::Response>>>;
-    type Error = h2::Error;
+    type Error = ::error::Never;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         self.inner.poll()

--- a/src/server/client_streaming.rs
+++ b/src/server/client_streaming.rs
@@ -1,7 +1,7 @@
 use codec::{Encode, Encoder};
 use generic::server::{ClientStreamingService, client_streaming, unary};
 
-use {h2, http, prost};
+use {http, prost};
 use futures::{Future, Poll, Stream};
 
 use std::fmt;
@@ -37,7 +37,7 @@ where
     T::Response: prost::Message,
 {
     type Item = http::Response<Encode<unary::Once<T::Response>>>;
-    type Error = h2::Error;
+    type Error = ::error::Never;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let response = try_ready!(self.inner.poll());

--- a/src/server/server_streaming.rs
+++ b/src/server/server_streaming.rs
@@ -4,7 +4,7 @@ use generic::server::{ServerStreamingService, server_streaming};
 
 use std::fmt;
 
-use {h2, http, prost};
+use {http, prost};
 use futures::{Future, Poll};
 
 pub struct ResponseFuture<T, B, R>
@@ -37,7 +37,7 @@ where T: ServerStreamingService<R>,
       B: Body,
 {
     type Item = http::Response<Encode<T::ResponseStream>>;
-    type Error = h2::Error;
+    type Error = ::error::Never;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let response = try_ready!(self.inner.poll());

--- a/src/server/streaming.rs
+++ b/src/server/streaming.rs
@@ -1,7 +1,7 @@
 use codec::{Encode, Encoder};
 use generic::server::{StreamingService, streaming};
 
-use {h2, http, prost};
+use {http, prost};
 use futures::{Future, Poll, Stream};
 
 use std::fmt;
@@ -39,7 +39,7 @@ where
     T::Response: prost::Message,
 {
     type Item = http::Response<Encode<T::ResponseStream>>;
-    type Error = h2::Error;
+    type Error = ::error::Never;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let response = try_ready!(self.inner.poll());

--- a/src/server/unary.rs
+++ b/src/server/unary.rs
@@ -5,7 +5,7 @@ use codec::{Encode, Encoder, Decoder};
 use generic::Streaming;
 use generic::server::{UnaryService, unary};
 
-use {h2, http, prost};
+use {http, prost};
 use futures::{Future, Poll};
 
 use std::fmt;
@@ -40,7 +40,7 @@ where T: UnaryService<R>,
       B: Body,
 {
     type Item = http::Response<Encode<Once<T::Response>>>;
-    type Error = h2::Error;
+    type Error = ::error::Never;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let response = try_ready!(self.inner.poll());

--- a/src/server/unimplemented.rs
+++ b/src/server/unimplemented.rs
@@ -1,5 +1,5 @@
 use futures::{Future, Poll};
-use {h2, http};
+use {http};
 
 use {Code, Status};
 
@@ -18,13 +18,14 @@ impl ResponseFuture {
 
 impl Future for ResponseFuture {
     type Item = http::Response<()>;
-    type Error = h2::Error;
+    type Error = ::error::Never;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let status = self.status.take().expect("polled after complete");
 
         let mut resp = http::Response::new(());
-        status.add_header(resp.headers_mut())?;
+        status.add_header(resp.headers_mut())
+            .expect("generated unimplemented message should be valid");
         Ok(resp.into())
     }
 }

--- a/tower-grpc-build/src/server.rs
+++ b/tower-grpc-build/src/server.rs
@@ -171,7 +171,7 @@ macro_rules! try_ready {
             .target_generic("T")
             .bound("T", &service.name)
             .associate_type("Response", &response_type)
-            .associate_type("Error", "h2::Error")
+            .associate_type("Error", "grpc::Never")
             .associate_type("Future", &format!("{}::ResponseFuture<T>", lower_name))
             ;
 
@@ -262,7 +262,7 @@ macro_rules! try_ready {
                 .impl_trait("tower::Service<()>")
                 .bound("T", &service.name)
                 .associate_type("Response", "Self")
-                .associate_type("Error", "h2::Error")
+                .associate_type("Error", "grpc::Never")
                 .associate_type("Future", "futures::FutureResult<Self::Response, Self::Error>")
                 ;
 
@@ -328,7 +328,7 @@ macro_rules! try_ready {
             .impl_trait("futures::Future")
             .bound("T", &service.name)
             .associate_type("Item", "http::Response<ResponseBody<T>>")
-            .associate_type("Error", "h2::Error")
+            .associate_type("Error", "grpc::Never")
             .new_fn("poll")
             .arg_mut_self()
             .ret("futures::Poll<Self::Item, Self::Error>")


### PR DESCRIPTION
I noticed that the generated and internal server `Future`s claim an error type of `h2::Error`, but they don't ever return an error (any error is instead turned into a `Response` with an appropriate `grpc-status`). This does two things:

- Reduces the coupling to `h2::Error`
- More properly conveys that these futures cannot error