### PR TITLE
Added custom_metadata interop test

### DIFF
--- a/tower-grpc-interop/Dockerfile-client-tower
+++ b/tower-grpc-interop/Dockerfile-client-tower
@@ -1,4 +1,4 @@
-FROM rust:1.23.0
+FROM rust:1.33.0
 
 COPY Cargo.toml Cargo.lock /usr/src/tower-grpc/
 COPY . /usr/src/tower-grpc/

--- a/tower-grpc-interop/docker-compose.yml
+++ b/tower-grpc-interop/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     build:
       context: ..
       dockerfile: tower-grpc-interop/Dockerfile-client-tower
-    command: --test_case=empty_unary --server_host="server-go" # this is the only one that works
+    command:
+    - --test_case=client_streaming,empty_stream,empty_unary,large_unary,ping_pong,server_streaming,status_code_and_message,unimplemented_method,unimplemented_service,special_status_message,custom_metadata
+    - --server_host="server-go"
     depends_on:
     - server-go

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -721,8 +721,8 @@ impl TestClients {
 
         let stream = stream::iter_ok(vec![make_ping_pong_request(0)]);
         let mut req_stream = Request::new(stream);
-        req_unary.metadata_mut().insert(key1, value1.clone());
-        req_unary.metadata_mut().insert_bin(key2, value2.clone());
+        req_stream.metadata_mut().insert(key1, value1.clone());
+        req_stream.metadata_mut().insert_bin(key2, value2.clone());
 
         let value1_cloned = value1.clone();
         let value2_cloned = value2.clone();
@@ -736,7 +736,8 @@ impl TestClients {
                         e.metadata().get(key1) == Some(&value1_cloned),
                         format!("result={:?}", e.metadata().get(key1))
                     ),
-                    // TODO trailing metadata not implemented?
+                    // TODO fails when run against reference go interop server
+                    // reading binary trailing metadata not implemented by client (see #27)
                     test_assert!(
                         "metadata bin must match in unary",
                         e.metadata().get_bin(key2) == Some(&value2_cloned),
@@ -752,7 +753,6 @@ impl TestClients {
             .map(move |e| {
                 println!("{:?}", e.metadata());
                 vec![
-                    // TODO no metadata returned
                     test_assert!(
                         "metadata string must match in duplex",
                         e.metadata().get(key1) == Some(&value1),

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -32,7 +32,7 @@ use pb::client::UnimplementedService;
 use pb::SimpleRequest;
 use pb::StreamingInputCallRequest;
 
-mod pb {
+pub mod pb {
     #![allow(dead_code)]
     #![allow(unused_imports)]
     include!(concat!(env!("OUT_DIR"), "/grpc.testing.rs"));
@@ -700,6 +700,78 @@ impl TestClients {
                 future::ok::<Vec<TestAssertion>, Box<Error>>(assertions)
             })
     }
+
+    fn custom_metadata_test(
+        &mut self,
+    ) -> impl Future<Item = Vec<TestAssertion>, Error = Box<Error>> {
+        let key1 = "x-grpc-test-echo-initial";
+        let value1 = MetadataValue::from_str("test_initial_metadata_value").unwrap();
+        let key2 = "x-grpc-test-echo-trailing-bin";
+        let value2 = MetadataValue::from_bytes(&[0xab, 0xab, 0xab]);
+
+        let req = SimpleRequest {
+            response_type: pb::PayloadType::Compressable as i32,
+            response_size: LARGE_RSP_SIZE,
+            payload: Some(util::client_payload(LARGE_REQ_SIZE)),
+            ..Default::default()
+        };
+        let mut req_unary = Request::new(req);
+        req_unary.metadata_mut().insert(key1, value1.clone());
+        req_unary.metadata_mut().insert_bin(key2, value2.clone());
+
+        let stream = stream::iter_ok(vec![make_ping_pong_request(0)]);
+        let mut req_stream = Request::new(stream);
+        req_unary.metadata_mut().insert(key1, value1.clone());
+        req_unary.metadata_mut().insert_bin(key2, value2.clone());
+
+        let value1_cloned = value1.clone();
+        let value2_cloned = value2.clone();
+        let unary = self
+            .test_client
+            .unary_call(req_unary)
+            .map(move |e| {
+                vec![
+                    test_assert!(
+                        "metadata string must match in unary",
+                        e.metadata().get(key1) == Some(&value1_cloned),
+                        format!("result={:?}", e.metadata().get(key1))
+                    ),
+                    // TODO trailing metadata not implemented?
+                    test_assert!(
+                        "metadata bin must match in unary",
+                        e.metadata().get_bin(key2) == Some(&value2_cloned),
+                        format!("result={:?}", e.metadata().get_bin(key1))
+                    ),
+                ]
+            })
+            .map_err(|tower_error| -> Box<Error> { Box::new(tower_error) });
+
+        let duplex = self
+            .test_client
+            .full_duplex_call(req_stream)
+            .map(move |e| {
+                println!("{:?}", e.metadata());
+                vec![
+                    // TODO no metadata returned
+                    test_assert!(
+                        "metadata string must match in duplex",
+                        e.metadata().get(key1) == Some(&value1),
+                        format!("result={:?}", e.metadata().get(key1))
+                    ),
+                    test_assert!(
+                        "metadata bin must match in duplex",
+                        e.metadata().get_bin(key2) == Some(&value2),
+                        format!("result={:?}", e.metadata().get_bin(key1))
+                    ),
+                ]
+            })
+            .map_err(|tower_error| -> Box<Error> { Box::new(tower_error) });
+
+        unary.join(duplex).map(|(mut l, mut r)| {
+            l.append(&mut r);
+            l
+        })
+    }
 }
 
 impl Testcase {
@@ -746,6 +818,7 @@ impl Testcase {
             Testcase::special_status_message => core.run(clients.special_status_message_test()),
             Testcase::unimplemented_method => core.run(clients.unimplemented_method_test()),
             Testcase::unimplemented_service => core.run(clients.unimplemented_service_test()),
+            Testcase::custom_metadata => core.run(clients.custom_metadata_test()),
             Testcase::compute_engine_creds
             | Testcase::jwt_token_creds
             | Testcase::oauth2_auth_token

--- a/tower-grpc-interop/travis-interop.sh
+++ b/tower-grpc-interop/travis-interop.sh
@@ -37,4 +37,4 @@ trap 'echo ":; killing test server"; kill ${SERVER_PID};' EXIT
 
 # run the interop test client against the server.
 cargo run -p tower-grpc-interop --bin client -- \
-    --test_case=client_streaming,empty_stream,empty_unary,large_unary,ping_pong,server_streaming,status_code_and_message,unimplemented_method,unimplemented_service,special_status_message
+    --test_case=client_streaming,empty_stream,empty_unary,large_unary,ping_pong,server_streaming,status_code_and_message,unimplemented_method,unimplemented_service,special_status_message,custom_metadata


### PR DESCRIPTION
Issue: #27 

Some issues I encountered
- Test server returns no binary metadata. This may be due to the fact that trailing metadata are not fully supported as mentioned in #90 
- No metadata returned for duplex calls at all