### PR TITLE
Use tower-request-modifier

### DIFF
--- a/tower-grpc-examples/Cargo.toml
+++ b/tower-grpc-examples/Cargo.toml
@@ -36,7 +36,7 @@ http = "0.1"
 prost = "0.5"
 tokio = "0.1"
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
-tower-add-origin = { git = "https://github.com/tower-rs/tower-http" }
+tower-request-modifier = { git = "https://github.com/tower-rs/tower-http" }
 tower-grpc = { path = "../" }
 tower-service = "0.2"
 tower-util = { git = "https://github.com/tower-rs/tower" }

--- a/tower-grpc-examples/src/helloworld/client.rs
+++ b/tower-grpc-examples/src/helloworld/client.rs
@@ -5,9 +5,9 @@ extern crate http;
 extern crate log;
 extern crate prost;
 extern crate tokio;
-extern crate tower_add_origin;
 extern crate tower_grpc;
 extern crate tower_h2;
+extern crate tower_request_modifier;
 extern crate tower_service;
 extern crate tower_util;
 
@@ -36,8 +36,8 @@ pub fn main() {
         .map(move |conn| {
             use hello_world::client::Greeter;
 
-            let conn = tower_add_origin::Builder::new()
-                .uri(uri)
+            let conn = tower_request_modifier::Builder::new()
+                .set_origin(uri)
                 .build(conn)
                 .unwrap();
 

--- a/tower-grpc-examples/src/metadata/client.rs
+++ b/tower-grpc-examples/src/metadata/client.rs
@@ -5,9 +5,9 @@ extern crate http;
 extern crate log;
 extern crate prost;
 extern crate tokio;
-extern crate tower_add_origin;
 extern crate tower_grpc;
 extern crate tower_h2;
+extern crate tower_request_modifier;
 extern crate tower_service;
 extern crate tower_util;
 
@@ -36,8 +36,8 @@ pub fn main() {
         .map(move |conn| {
             use metadata::client::Doorman;
 
-            let conn = tower_add_origin::Builder::new()
-                .uri(uri)
+            let conn = tower_request_modifier::Builder::new()
+                .set_origin(uri)
                 .build(conn)
                 .unwrap();
 

--- a/tower-grpc-examples/src/routeguide/client.rs
+++ b/tower-grpc-examples/src/routeguide/client.rs
@@ -8,9 +8,9 @@ extern crate http;
 extern crate log;
 extern crate prost;
 extern crate tokio;
-extern crate tower_add_origin;
 extern crate tower_grpc;
 extern crate tower_h2;
+extern crate tower_request_modifier;
 extern crate tower_service;
 extern crate tower_util;
 
@@ -52,8 +52,8 @@ pub fn main() {
         .map(move |conn| {
             use routeguide::client::RouteGuide;
 
-            let conn = tower_add_origin::Builder::new()
-                .uri(uri)
+            let conn = tower_request_modifier::Builder::new()
+                .set_origin(uri)
                 .build(conn)
                 .unwrap();
 

--- a/tower-grpc-interop/Cargo.toml
+++ b/tower-grpc-interop/Cargo.toml
@@ -22,7 +22,7 @@ prost = "0.5"
 tokio-core = "0.1"
 tokio = "0.1"
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
-tower-add-origin = { git = "https://github.com/tower-rs/tower-http" }
+tower-request-modifier = { git = "https://github.com/tower-rs/tower-http" }
 tower-grpc = { path = "../" }
 tower-service = "0.2"
 

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -10,9 +10,9 @@ extern crate log;
 extern crate prost;
 extern crate rustls;
 extern crate tokio_core;
-extern crate tower_add_origin;
 extern crate tower_grpc;
 extern crate tower_h2;
+extern crate tower_request_modifier;
 
 use std::error::Error;
 use std::fmt;
@@ -228,22 +228,24 @@ fn assert_success(
 
 struct TestClients {
     test_client: TestService<
-        tower_add_origin::AddOrigin<
+        tower_request_modifier::RequestModifier<
             tower_h2::client::Connection<
                 tokio_core::net::TcpStream,
                 tokio_core::reactor::Handle,
                 tower_grpc::BoxBody,
             >,
+            tower_grpc::BoxBody,
         >,
     >,
 
     unimplemented_client: UnimplementedService<
-        tower_add_origin::AddOrigin<
+        tower_request_modifier::RequestModifier<
             tower_h2::client::Connection<
                 tokio_core::net::TcpStream,
                 tokio_core::reactor::Handle,
                 tower_grpc::BoxBody,
             >,
+            tower_grpc::BoxBody,
         >,
     >,
 }
@@ -718,8 +720,8 @@ impl Testcase {
                             .map_err(|_| panic!("failed HTTP/2.0 handshake"))
                     })
                     .map(move |conn| {
-                        tower_add_origin::Builder::new()
-                            .uri(server.uri.clone())
+                        tower_request_modifier::Builder::new()
+                            .set_origin(server.uri.clone())
                             .build(conn)
                             .unwrap()
                     }),


### PR DESCRIPTION
Switch from `tower-add-origin` to `tower-request-modifier`. I was hoping this would serve as a clean minimal representation of a trait issue I'm having elsewhere, but it ended up being an easy conversion.