### PR TITLE
Use published tower-util 0.1 instead of from git

### DIFF
--- a/tower-grpc-examples/Cargo.toml
+++ b/tower-grpc-examples/Cargo.toml
@@ -39,7 +39,7 @@ tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-request-modifier = { git = "https://github.com/tower-rs/tower-http" }
 tower-grpc = { path = "../tower-grpc" }
 tower-service = "0.2"
-tower-util = { git = "https://github.com/tower-rs/tower" }
+tower-util = "0.1"
 
 # For the routeguide example
 serde = "1.0"

--- a/tower-grpc/Cargo.toml
+++ b/tower-grpc/Cargo.toml
@@ -23,7 +23,7 @@ percent-encoding = "1.0.1"
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2", optional = true }
 tower-http = { git = "https://github.com/tower-rs/tower-http" }
 tower-service = "0.2"
-tower-util = { git = "https://github.com/tower-rs/tower" }
+tower-util = "0.1"
 
 # For protobuf
 prost = { version = "0.5", optional = true }


### PR DESCRIPTION
Now when tower/tower has been published to crates.io (which is great!), if one was using tower-grpc one would get the git version of tower-util in addition to v0.1 from crates.io if one was using tower in general.

So here is an upgrade of tower-util to v0.1 from crates.io instead of the old git dependency.