### PR TITLE
Update examples to compile with latest tower-hyper

### DIFF
--- a/tower-grpc-examples/src/helloworld/server.rs
+++ b/tower-grpc-examples/src/helloworld/server.rs
@@ -15,7 +15,6 @@ pub mod hello_world {
 use hello_world::{server, HelloReply, HelloRequest};
 
 use futures::{future, Future, Stream};
-use tokio::executor::DefaultExecutor;
 use tokio::net::TcpListener;
 use tower_grpc::{Request, Response};
 use tower_hyper::server::{Http, Server};
@@ -45,7 +44,6 @@ pub fn main() {
     let mut server = Server::new(new_service);
 
     let http = Http::new().http2_only(true).clone();
-    let http = http.with_executor(DefaultExecutor::current());
 
     let addr = "[::1]:50051".parse().unwrap();
     let bind = TcpListener::bind(&addr).expect("bind");

--- a/tower-grpc-examples/src/metadata/server.rs
+++ b/tower-grpc-examples/src/metadata/server.rs
@@ -16,7 +16,6 @@ pub mod metadata {
 use metadata::{server, EnterReply, EnterRequest};
 
 use futures::{future, Future, Stream};
-use tokio::executor::DefaultExecutor;
 use tokio::net::TcpListener;
 use tower_grpc::{Request, Response};
 use tower_hyper::server::{Http, Server};
@@ -54,7 +53,6 @@ pub fn main() {
     let mut server = Server::new(new_service);
 
     let http = Http::new().http2_only(true).clone();
-    let http = http.with_executor(DefaultExecutor::current());
 
     let addr = "[::1]:50051".parse().unwrap();
     let bind = TcpListener::bind(&addr).expect("bind");

--- a/tower-grpc-examples/src/routeguide/server.rs
+++ b/tower-grpc-examples/src/routeguide/server.rs
@@ -24,7 +24,6 @@ use routeguide::{server, Feature, Point, Rectangle, RouteNote, RouteSummary};
 
 use futures::sync::mpsc;
 use futures::{future, stream, Future, Sink, Stream};
-use tokio::executor::DefaultExecutor;
 use tokio::net::TcpListener;
 use tower_grpc::{Request, Response, Streaming};
 use tower_hyper::server::{Http, Server};
@@ -251,7 +250,6 @@ pub fn main() {
 
     let mut server = Server::new(new_service);
     let http = Http::new().http2_only(true).clone();
-    let http = http.with_executor(DefaultExecutor::current());
 
     let addr = "127.0.0.1:10000".parse().unwrap();
     let bind = TcpListener::bind(&addr).expect("bind");


### PR DESCRIPTION
As mentioned in the gitter chat, the examples were not compiling due to changes made in tower-hyper. This PR fixes that.