### PR TITLE
Remove tower-h2 in favor of tower-hyper in tests

### DIFF
--- a/tests/multifile/Cargo.toml
+++ b/tests/multifile/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [dependencies]
 bytes = "0.4"
 prost = "0.5"
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
-tower-grpc = { path = "../../tower-grpc" }
+tower-hyper = { git = "https://github.com/tower-rs/tower-hyper" }
+tower-grpc = { path = "../../tower-grpc", features = ["tower-hyper"] }
 
 [build-dependencies]
-tower-grpc-build = { path = "../../tower-grpc-build" }
+tower-grpc-build = { path = "../../tower-grpc-build", features = ["tower-hyper"] }

--- a/tests/multifile/src/lib.rs
+++ b/tests/multifile/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate bytes;
 extern crate prost;
 extern crate tower_grpc;
-extern crate tower_h2;
+extern crate tower_hyper;
 
 pub mod hello {
     include!(concat!(env!("OUT_DIR"), "/hello.rs"));

--- a/tests/name-case/Cargo.toml
+++ b/tests/name-case/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 bytes = "0.4"
 prost = "0.5"
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
+tower-hyper = { git = "https://github.com/tower-rs/tower-hyper" }
 tower-grpc = { path = "../../tower-grpc" }
 
 [build-dependencies]

--- a/tests/name-case/src/lib.rs
+++ b/tests/name-case/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate bytes;
 extern crate prost;
 extern crate tower_grpc;
-extern crate tower_h2;
+extern crate tower_hyper;
 
 pub mod hello {
     include!(concat!(env!("OUT_DIR"), "/hello.rs"));

--- a/tests/unused-imports/Cargo.toml
+++ b/tests/unused-imports/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 bytes = "0.4"
 prost = "0.5"
+tower-hyper = { git = "https://github.com/tower-rs/tower-hyper" }
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-grpc = { path = "../../tower-grpc" }
 

--- a/tests/unused-imports/Cargo.toml
+++ b/tests/unused-imports/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 bytes = "0.4"
 prost = "0.5"
 tower-hyper = { git = "https://github.com/tower-rs/tower-hyper" }
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-grpc = { path = "../../tower-grpc" }
 
 [build-dependencies]

--- a/tests/unused-imports/src/lib.rs
+++ b/tests/unused-imports/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate bytes;
 extern crate prost;
 extern crate tower_grpc;
-extern crate tower_h2;
+extern crate tower_hyper;
 
 pub mod server_streaming {
     include!(concat!(env!("OUT_DIR"), "/server_streaming.rs"));

--- a/tests/uses_empty/Cargo.toml
+++ b/tests/uses_empty/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 publish = false
 
 [dependencies]
-tower-grpc = { path = "../../tower-grpc", features = ["tower-h2"] }
+tower-grpc = { path = "../../tower-grpc", features = ["tower-hyper"] }
 
 [build-dependencies]
-tower-grpc-build = { path = "../../tower-grpc-build", features = ["tower-h2"] }
+tower-grpc-build = { path = "../../tower-grpc-build", features = ["tower-hyper"] }

--- a/tower-grpc-build/Cargo.toml
+++ b/tower-grpc-build/Cargo.toml
@@ -10,5 +10,4 @@ prost-build = "0.5"
 heck = "0.3"
 
 [features]
-tower-h2 = []
 tower-hyper = []

--- a/tower-grpc-build/src/server.rs
+++ b/tower-grpc-build/src/server.rs
@@ -281,41 +281,6 @@ macro_rules! try_ready {
                 .line("futures::ok(self.clone())");
         }
 
-        #[cfg(feature = "tower-h2")]
-        // Service that converts tower_grpc::BoxBody to tower_h2 bodies
-        {
-            let imp = scope
-                .new_impl(&name)
-                .generic("T")
-                .target_generic("T")
-                .impl_trait("tower::Service<http::Request<tower_h2::RecvBody>>")
-                .bound("T", &service.name)
-                .associate_type(
-                    "Response",
-                    "<Self as tower::Service<http::Request<grpc::BoxBody>>>::Response",
-                )
-                .associate_type(
-                    "Error",
-                    "<Self as tower::Service<http::Request<grpc::BoxBody>>>::Error",
-                )
-                .associate_type(
-                    "Future",
-                    "<Self as tower::Service<http::Request<grpc::BoxBody>>>::Future",
-                );
-
-            imp.new_fn("poll_ready")
-                .arg_mut_self()
-                .ret("futures::Poll<(), Self::Error>")
-                .line("tower::Service::<http::Request<grpc::BoxBody>>::poll_ready(self)");
-
-            imp.new_fn("call")
-                .arg_mut_self()
-                .arg("request", "http::Request<tower_h2::RecvBody>")
-                .ret("Self::Future")
-                .line("let request = request.map(|b| grpc::BoxBody::map_from(b));")
-                .line("tower::Service::<http::Request<grpc::BoxBody>>::call(self, request)");
-        }
-
         #[cfg(feature = "tower-hyper")]
         // Service that converts tower_grpc::BoxBody to tower_hyper bodies
         {

--- a/tower-grpc-interop/Cargo.toml
+++ b/tower-grpc-interop/Cargo.toml
@@ -21,10 +21,11 @@ http = "0.1"
 prost = "0.5"
 tokio-core = "0.1"
 tokio = "0.1"
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
+tower-hyper = { git = "https://github.com/tower-rs/tower-hyper" }
 tower-request-modifier = { git = "https://github.com/tower-rs/tower-http" }
 tower-grpc = { path = "../tower-grpc" }
 tower-service = "0.2"
+http-connection = { git = "https://github.com/hyperium/http-connection" }
 
 clap = "~2.29"
 console = "0.7"
@@ -32,4 +33,4 @@ rustls = "0.14.0"
 domain = "0.2.2"
 
 [build-dependencies]
-tower-grpc-build = { path = "../tower-grpc-build", features = ["tower-h2"] }
+tower-grpc-build = { path = "../tower-grpc-build", features = ["tower-hyper"] }

--- a/tower-grpc-interop/Cargo.toml
+++ b/tower-grpc-interop/Cargo.toml
@@ -24,7 +24,7 @@ tokio = "0.1"
 tower-hyper = { git = "https://github.com/tower-rs/tower-hyper" }
 tower-request-modifier = { git = "https://github.com/tower-rs/tower-http" }
 tower-grpc = { path = "../tower-grpc" }
-tower-service = "0.2"
+tower = "0.1"
 http-connection = { git = "https://github.com/hyperium/http-connection" }
 
 clap = "~2.29"

--- a/tower-grpc-interop/Dockerfile-server-go
+++ b/tower-grpc-interop/Dockerfile-server-go
@@ -1,35 +1,19 @@
-[package]
-name = "tower-grpc-interop"
-version = "0.0.1"
-authors = ["Eliza Weisman <eliza@buoyant.io>"]
-license = "MIT"
+FROM golang:1.9 as build
 
-[[bin]]
-name = "client"
-path = "src/client.rs"
+ENV PACKAGE google.golang.org/grpc/interop/server
+ENV PACKAGEDIR $GOPATH/src/$PACKAGE
 
-[[bin]]
-name = "server"
-path = "src/server.rs"
+RUN go get -u $PACKAGE
 
-[dependencies]
-futures = "0.1.23"
-bytes = "0.4"
-pretty_env_logger = "0.2"
-log = "0.4"
-http = "0.1"
-prost = "0.5"
-tokio-core = "0.1"
-tokio = "0.1"
-tower-hyper = { git = "https://github.com/tower-rs/tower-hyper" }
-tower-request-modifier = { git = "https://github.com/tower-rs/tower-http" }
-tower-grpc = { path = "../tower-grpc", features = ["tower-hyper"] }
-tower-service = "0.2"
+WORKDIR $PACKAGEDIR
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o server .
 
-clap = "~2.29"
-console = "0.7"
-rustls = "0.14.0"
-domain = "0.2.2"
+FROM alpine:latest
 
-[build-dependencies]
-tower-grpc-build = { path = "../tower-grpc-build", features = ["tower-hyper"] }
+ENV PACKAGE google.golang.org/grpc/interop/server
+ENV PACKAGEDIR $GOPATH/src/$PACKAGE
+
+WORKDIR /root/
+COPY --from=build /go/src/google.golang.org/grpc/interop/server/server .
+
+ENTRYPOINT ["./server"]

--- a/tower-grpc-interop/Dockerfile-server-go
+++ b/tower-grpc-interop/Dockerfile-server-go
@@ -1,19 +1,36 @@
-FROM golang:1.9 as build
+[package]
+name = "tower-grpc-interop"
+version = "0.0.1"
+authors = ["Eliza Weisman <eliza@buoyant.io>"]
+license = "MIT"
 
-ENV PACKAGE google.golang.org/grpc/interop/server
-ENV PACKAGEDIR $GOPATH/src/$PACKAGE
+[[bin]]
+name = "client"
+path = "src/client.rs"
 
-RUN go get -u $PACKAGE
+[[bin]]
+name = "server"
+path = "src/server.rs"
 
-WORKDIR $PACKAGEDIR
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o server .
+[dependencies]
+futures = "0.1.23"
+bytes = "0.4"
+pretty_env_logger = "0.2"
+log = "0.4"
+http = "0.1"
+prost = "0.5"
+tokio-core = "0.1"
+tokio = "0.1"
+tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
+tower-hyper = { git = "https://github.com/tower-rs/tower-hyper" }
+tower-request-modifier = { git = "https://github.com/tower-rs/tower-http" }
+tower-grpc = { path = "../tower-grpc", features = ["tower-hyper"] }
+tower-service = "0.2"
 
-FROM alpine:latest
+clap = "~2.29"
+console = "0.7"
+rustls = "0.14.0"
+domain = "0.2.2"
 
-ENV PACKAGE google.golang.org/grpc/interop/server
-ENV PACKAGEDIR $GOPATH/src/$PACKAGE
-
-WORKDIR /root/
-COPY --from=build /go/src/google.golang.org/grpc/interop/server/server .
-
-ENTRYPOINT ["./server"]
+[build-dependencies]
+tower-grpc-build = { path = "../tower-grpc-build", features = ["tower-hyper", "tower-h2"] }

--- a/tower-grpc-interop/Dockerfile-server-go
+++ b/tower-grpc-interop/Dockerfile-server-go
@@ -21,7 +21,6 @@ http = "0.1"
 prost = "0.5"
 tokio-core = "0.1"
 tokio = "0.1"
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-hyper = { git = "https://github.com/tower-rs/tower-hyper" }
 tower-request-modifier = { git = "https://github.com/tower-rs/tower-http" }
 tower-grpc = { path = "../tower-grpc", features = ["tower-hyper"] }
@@ -33,4 +32,4 @@ rustls = "0.14.0"
 domain = "0.2.2"
 
 [build-dependencies]
-tower-grpc-build = { path = "../tower-grpc-build", features = ["tower-hyper", "tower-h2"] }
+tower-grpc-build = { path = "../tower-grpc-build", features = ["tower-hyper"] }

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -23,6 +23,7 @@ use std::str::FromStr;
 
 use futures::{future, stream, Future, Poll, Stream};
 use http::uri::{self, Uri};
+use http::Version;
 use http_connection::HttpConnection;
 use tokio_core::net::TcpStream;
 use tokio_core::reactor;
@@ -821,10 +822,14 @@ impl Testcase {
                     <TcpStream as tokio::io::AsyncWrite>::shutdown(&mut self.0)
                 }
             }
-            impl HttpConnection for Stream {}
+            impl HttpConnection for Stream {
+                fn version(&self) -> Option<Version> {
+                    Some(Version::HTTP_2)
+                }
+            }
 
-            let builder = Builder::new().http2_only(true).clone();
-            let mut connector = Connect::with_builder(TcpConnector(reactor.clone()), builder);
+            // let builder = Builder::new().http2_only(true).clone();
+            let mut connector = Connect::new(TcpConnector(reactor.clone()));
 
             core.run(connector.call(server.addr).map(move |conn| {
                 tower_request_modifier::Builder::new()

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -28,7 +28,7 @@ use tokio_core::net::TcpStream;
 use tokio_core::reactor;
 use tower_grpc::metadata::MetadataValue;
 use tower_grpc::Request;
-use tower_hyper::client::{Connect, Connection};
+use tower_hyper::client::{Builder, Connect};
 use tower_service::Service;
 
 use pb::client::TestService;
@@ -823,7 +823,8 @@ impl Testcase {
             }
             impl HttpConnection for Stream {}
 
-            let mut connector = Connect::new(TcpConnector(reactor.clone()));
+            let builder = Builder::new().http2_only(true).clone();
+            let mut connector = Connect::with_builder(TcpConnector(reactor.clone()), builder);
 
             core.run(connector.call(server.addr).map(move |conn| {
                 tower_request_modifier::Builder::new()

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -233,22 +233,14 @@ fn assert_success(
 struct TestClients {
     test_client: TestService<
         tower_request_modifier::RequestModifier<
-            tower_hyper::client::Connection<
-                // tokio_core::net::TcpStream,
-                // tokio_core::reactor::Handle,
-                tower_grpc::BoxBody,
-            >,
+            tower_hyper::client::Connection<tower_grpc::BoxBody>,
             tower_grpc::BoxBody,
         >,
     >,
 
     unimplemented_client: UnimplementedService<
         tower_request_modifier::RequestModifier<
-            tower_hyper::client::Connection<
-                // tokio_core::net::TcpStream,
-                // tokio_core::reactor::Handle,
-                tower_grpc::BoxBody,
-            >,
+            tower_hyper::client::Connection<tower_grpc::BoxBody>,
             tower_grpc::BoxBody,
         >,
     >,

--- a/tower-grpc-interop/src/client.rs
+++ b/tower-grpc-interop/src/client.rs
@@ -27,7 +27,7 @@ use http::Version;
 use http_connection::HttpConnection;
 use tokio_core::net::TcpStream;
 use tokio_core::reactor;
-use tower::{Service, ServiceExt};
+use tower::{buffer::Buffer, Service, ServiceExt};
 use tower_grpc::metadata::MetadataValue;
 use tower_grpc::Request;
 use tower_hyper::client::{Builder, Connect};
@@ -233,16 +233,22 @@ fn assert_success(
 
 struct TestClients {
     test_client: TestService<
-        tower_request_modifier::RequestModifier<
-            tower_hyper::client::Connection<tower_grpc::BoxBody>,
-            tower_grpc::BoxBody,
+        Buffer<
+            tower_request_modifier::RequestModifier<
+                tower_hyper::client::Connection<tower_grpc::BoxBody>,
+                tower_grpc::BoxBody,
+            >,
+            http::Request<tower_grpc::BoxBody>,
         >,
     >,
 
     unimplemented_client: UnimplementedService<
-        tower_request_modifier::RequestModifier<
-            tower_hyper::client::Connection<tower_grpc::BoxBody>,
-            tower_grpc::BoxBody,
+        Buffer<
+            tower_request_modifier::RequestModifier<
+                tower_hyper::client::Connection<tower_grpc::BoxBody>,
+                tower_grpc::BoxBody,
+            >,
+            http::Request<tower_grpc::BoxBody>,
         >,
     >,
 }
@@ -599,14 +605,15 @@ impl TestClients {
             .unary_call(Request::new(simple_req))
             .then(&validate_response);
 
-        let full_duplex_call = self
-            .test_client
-            .full_duplex_call(Request::new(stream::iter_ok(vec![duplex_req])))
-            .and_then(|response_stream| {
-                // Convert the stream into a plain Vec
-                response_stream.into_inner().map_err(From::from).collect()
-            })
-            .then(&validate_response);
+        let full_duplex_call = self.test_client.clone().ready().then(|svc| {
+            svc.unwrap()
+                .full_duplex_call(Request::new(stream::iter_ok(vec![duplex_req])))
+                .and_then(|response_stream| {
+                    // Convert the stream into a plain Vec
+                    response_stream.into_inner().map_err(From::from).collect()
+                })
+                .then(&validate_response)
+        });
 
         unary_call
             .join(full_duplex_call)
@@ -833,10 +840,12 @@ impl Testcase {
 
             core.run(connector.ready().and_then(|mut connector| {
                 connector.call(server.addr).map(move |conn| {
-                    tower_request_modifier::Builder::new()
+                    let svc = tower_request_modifier::Builder::new()
                         .set_origin(server.uri.clone())
                         .build(conn)
-                        .unwrap()
+                        .unwrap();
+
+                    Buffer::new(svc, 5)
                 })
             }))
             .expect("connection")

--- a/tower-grpc-interop/src/server.rs
+++ b/tower-grpc-interop/src/server.rs
@@ -10,7 +10,6 @@ extern crate tower_grpc;
 extern crate tower_hyper;
 
 use futures::{future, stream, Future, Stream};
-use tokio::executor::DefaultExecutor;
 use tokio::net::TcpListener;
 use tower_grpc::{Code, Request, Response, Status};
 use tower_hyper::server::Server;

--- a/tower-grpc-interop/src/server.rs
+++ b/tower-grpc-interop/src/server.rs
@@ -7,13 +7,13 @@ extern crate pretty_env_logger;
 extern crate prost;
 extern crate tokio;
 extern crate tower_grpc;
-extern crate tower_h2;
+extern crate tower_hyper;
 
 use futures::{future, stream, Future, Stream};
 use tokio::executor::DefaultExecutor;
 use tokio::net::TcpListener;
 use tower_grpc::{Code, Request, Response, Status};
-use tower_h2::Server;
+use tower_hyper::server::Server;
 
 mod pb {
     #![allow(dead_code)]
@@ -208,8 +208,7 @@ fn main() {
 
     let new_service = pb::server::TestServiceServer::new(Test);
 
-    let h2_settings = Default::default();
-    let mut h2 = Server::new(new_service, h2_settings, DefaultExecutor::current());
+    let mut server = Server::new(new_service);
 
     let addr = format!("0.0.0.0:{}", port).parse().unwrap();
     let bind = TcpListener::bind(&addr).expect("bind");
@@ -221,8 +220,8 @@ fn main() {
                 return Err(e);
             }
 
-            let serve = h2.serve(sock);
-            tokio::spawn(serve.map_err(|e| error!("h2 error: {:?}", e)));
+            let serve = server.serve(sock);
+            tokio::spawn(serve.map_err(|e| error!("hyper error: {:?}", e)));
 
             Ok(())
         })

--- a/tower-grpc-interop/src/server.rs
+++ b/tower-grpc-interop/src/server.rs
@@ -12,7 +12,7 @@ extern crate tower_hyper;
 use futures::{future, stream, Future, Stream};
 use tokio::net::TcpListener;
 use tower_grpc::{Code, Request, Response, Status};
-use tower_hyper::server::Server;
+use tower_hyper::server::{Http, Server};
 
 mod pb {
     #![allow(dead_code)]
@@ -211,6 +211,7 @@ fn main() {
 
     let addr = format!("0.0.0.0:{}", port).parse().unwrap();
     let bind = TcpListener::bind(&addr).expect("bind");
+    let http = Http::new().http2_only(true).clone();
 
     let serve = bind
         .incoming()
@@ -219,7 +220,7 @@ fn main() {
                 return Err(e);
             }
 
-            let serve = server.serve(sock);
+            let serve = server.serve_with(sock, http.clone());
             tokio::spawn(serve.map_err(|e| error!("hyper error: {:?}", e)));
 
             Ok(())

--- a/tower-grpc-interop/travis-interop.sh
+++ b/tower-grpc-interop/travis-interop.sh
@@ -37,4 +37,4 @@ trap 'echo ":; killing test server"; kill ${SERVER_PID};' EXIT
 
 # run the interop test client against the server.
 cargo run -p tower-grpc-interop --bin client -- \
-    --test_case=client_streaming,empty_stream,empty_unary,large_unary,ping_pong,server_streaming,status_code_and_message,unimplemented_method,unimplemented_service,special_status_message,custom_metadata
+      --test_case=client_streaming,empty_stream,empty_unary,large_unary,ping_pong,server_streaming,status_code_and_message,unimplemented_method,unimplemented_service,special_status_message,custom_metadata

--- a/tower-grpc/Cargo.toml
+++ b/tower-grpc/Cargo.toml
@@ -20,7 +20,6 @@ http = "0.1.14"
 h2 = "0.1.11"
 log = "0.4"
 percent-encoding = "1.0.1"
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2", optional = true }
 tower-hyper = { git = "http://github.com/tower-rs/tower-hyper", optional = true }
 tower-http = { git = "https://github.com/tower-rs/tower-http" }
 tower-service = "0.2"

--- a/tower-grpc/src/codegen.rs
+++ b/tower-grpc/src/codegen.rs
@@ -33,12 +33,6 @@ pub mod server {
     pub mod tower_hyper {
         pub use tower_hyper::Body;
     }
-
-    #[cfg(feature = "tower-h2")]
-    /// Re-exported types from `tower-h2` crate.
-    pub mod tower_h2 {
-        pub use tower_h2::{Body, RecvBody};
-    }
 }
 
 pub mod client {

--- a/tower-grpc/src/lib.rs
+++ b/tower-grpc/src/lib.rs
@@ -16,8 +16,6 @@ extern crate tower_util;
 
 #[cfg(feature = "protobuf")]
 extern crate prost;
-#[cfg(feature = "tower-h2")]
-extern crate tower_h2;
 #[cfg(feature = "tower-hyper")]
 extern crate tower_hyper;
 


### PR DESCRIPTION
This removes all traces of tower-h2 from all the crates. This should get us one step closer to a release!