### PR TITLE
Remove tower-http infavor of http-body

### DIFF
--- a/tower-grpc/Cargo.toml
+++ b/tower-grpc/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4"
 percent-encoding = "1.0.1"
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2", optional = true }
 tower-hyper = { git = "http://github.com/tower-rs/tower-hyper", optional = true }
-tower-http = { git = "https://github.com/tower-rs/tower-http" }
+http-body = "0.1"
 tower-service = "0.2"
 tower-util = "0.1"
 

--- a/tower-grpc/src/body.rs
+++ b/tower-grpc/src/body.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use bytes::{Buf, Bytes, IntoBuf};
 use futures::Poll;
 use http;
-pub use tower_http::Body as HttpBody;
+pub use http_body::Body as HttpBody;
 
 use self::sealed::Sealed;
 use error::Error;

--- a/tower-grpc/src/codegen.rs
+++ b/tower-grpc/src/codegen.rs
@@ -23,7 +23,7 @@ pub mod server {
 
     /// Re-exported types from the `tower` crate.
     pub mod tower {
-        pub use tower_http::Body as HttpBody;
+        pub use http_body::Body as HttpBody;
         pub use tower_service::Service;
         pub use tower_util::MakeService;
     }
@@ -59,6 +59,6 @@ pub mod client {
     }
 
     pub mod tower {
-        pub use tower_http::Body as HttpBody;
+        pub use http_body::Body as HttpBody;
     }
 }

--- a/tower-grpc/src/lib.rs
+++ b/tower-grpc/src/lib.rs
@@ -9,8 +9,8 @@ extern crate h2;
 extern crate http;
 #[macro_use]
 extern crate log;
+extern crate http_body;
 extern crate percent_encoding;
-extern crate tower_http;
 extern crate tower_service;
 extern crate tower_util;
 


### PR DESCRIPTION
This also brings us a step closer to releasing by removing another git dep for its published version.