### PR TITLE
Show usage of cargo:rerun-if-changed in examples

### DIFF
--- a/tower-grpc-examples/build.rs
+++ b/tower-grpc-examples/build.rs
@@ -8,6 +8,7 @@ fn main() {
             &["proto/helloworld"],
         )
         .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
+    println!("cargo:rerun-if-changed=proto/helloworld/helloworld.proto");
 
     // Build metadata
     tower_grpc_build::Config::new()
@@ -15,6 +16,7 @@ fn main() {
         .enable_client(true)
         .build(&["proto/metadata/metadata.proto"], &["proto/metadata"])
         .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
+    println!("cargo:rerun-if-changed=proto/metadata/metadata.proto");
 
     // Build routeguide
     tower_grpc_build::Config::new()
@@ -25,4 +27,5 @@ fn main() {
             &["proto/routeguide"],
         )
         .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
+    println!("cargo:rerun-if-changed=proto/routeguide/route_guide.proto");
 }


### PR DESCRIPTION
As the examples are going to be cribbed by application developers, it's important to demonstrate how rebuilds using tower-grpc-build can be reduced by printing `cargo:rerun-if-changed` instructions for cargo to only rerun the build script if the .proto files change.