### PR TITLE
Implement function for creating errors with binary `details` field

### DIFF
--- a/tower-grpc/src/status.rs
+++ b/tower-grpc/src/status.rs
@@ -59,6 +59,15 @@ impl Status {
         }
     }
 
+    /// Create a new `Status` with the associated code, message, and binary details field.
+    pub fn with_raw_details(code: Code, message: impl Into<String>, details: Bytes) -> Status {
+        Status {
+            code,
+            message: message.into(),
+            details: details,
+        }
+    }
+
     // Deprecated: this constructor encourages creating statuses with no
     // message, hurting later debugging.
     #[doc(hidden)]


### PR DESCRIPTION
This PR adds a function to create `Status` errors with the `details` field set.

This is not a complete solution - other libraries offer ways to encode a protobuf into this field. This change will allow for some experimentation and manual implementation for error details.

Related: https://github.com/tower-rs/tower-grpc/issues/136