### PR TITLE
UPDATE: Update the dependency(branch) of the h2 and typer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.idea

--- a/tower-grpc-examples/Cargo.toml
+++ b/tower-grpc-examples/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2018"
 authors = ["Carl Lerche <me@carllerche.com>"]
 publish = false
 
-# [[bin]]
-# name = "helloworld-server"
-# path = "src/helloworld/server.rs"
+ [[bin]]
+ name = "helloworld-server"
+ path = "src/helloworld/server.rs"
 
 [[bin]]
 name = "helloworld-client"
@@ -30,19 +30,19 @@ path = "src/helloworld/client.rs"
 # path = "src/routeguide/client.rs"
 
 [dependencies]
-futures = { package = "futures-preview", version = "=0.3.0-alpha.17" }
+futures = { package = "futures-preview", version = "=0.3.0-alpha.18" }
 bytes = "0.4"
 env_logger = { version = "0.5", default-features = false }
 log = "0.4"
 http = "0.1"
 prost = "0.5"
-tokio = "=0.2.0-alpha.1"
+tokio = "=0.2.0-alpha.5"
 # tower-request-modifier = { git = "https://github.com/tower-rs/tower-http" }
 # tower-hyper = "0.1"
-tower-h2 = { git = "https://github.com/LucioFranco/h2", branch = "lucio/tower-h2-hack" }
+h2 = { git = "https://github.com/LucioFranco/h2", branch = "0.1.x" }
 # hyper = "0.12"
-tower-grpc = { path = "../tower-grpc" }
-tower-service = { git = "https://github.com/tower-rs/tower", branch = "std-future" }
+tower-grpc = { path = "../tower-grpc", branch = "v0.3.x" }
+tower-service = { git = "https://github.com/tower-rs/tower", branch = "v0.3.x" }
 # tower-util = "0.1"
 
 # For the routeguide example

--- a/tower-grpc/Cargo.toml
+++ b/tower-grpc/Cargo.toml
@@ -27,7 +27,7 @@ protobuf = ["prost"]
 [dependencies]
 base64 = "0.10"
 bytes = "0.4.7"
-futures-preview = "=0.3.0-alpha.17"
+futures-preview = "=0.3.0-alpha.18"
 http = "0.1.14"
 h2 = "0.1.11"
 log = "0.4"
@@ -35,8 +35,8 @@ percent-encoding = "1.0.1"
 tower-hyper = { version = "0.1", optional = true }
 http-body = { git = "https://github.com/hyperium/http-body", branch = "std-future" }
 # http-body = { path = "../../http-body" }
-tower-service = { git = "https://github.com/tower-rs/tower", branch = "std-future" }
-tower-util = { git = "https://github.com/tower-rs/tower", branch = "std-future" }
+tower-service = { git = "https://github.com/tower-rs/tower", branch = "v0.3.x" }
+tower-util = { git = "https://github.com/tower-rs/tower", branch = "v0.3.x" }
 
 # For protobuf
 prost = { version = "0.5", optional = true }


### PR DESCRIPTION
However, this branch is still not working, for:
```
107 | impl<T: Unpin> TryStream for Once<T> {
    |                ^^^^^^^^^ the trait `futures_core::stream::Stream` is not implemented for `generic::server::unary::Once<T>`
    |
    = note: required because of the requirements on the impl of `futures_core::stream::private_try_stream::Sealed` for `generic::server::unary::Once<T>`
```